### PR TITLE
Implement proper Exception handling in DynamoDb connector ScanRecordReadRequest

### DIFF
--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/preader/PageResults.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/preader/PageResults.java
@@ -64,4 +64,8 @@ public class PageResults<V> {
   public boolean hasMore() {
     return pos < items.size();
   }
+
+  public boolean isFailed() {
+    return exception != null;
+  }
 }


### PR DESCRIPTION

When reads fail constantly for a particular page (number of retry exceeds) the exception will be logged and the page and whole segment will be discarded. As a result ReadWorker will loop forever waiting for the missing segment.