### PR TITLE
Add shim for Hive 1.2.x compatability

### DIFF
--- a/emr-dynamodb-hive/pom.xml
+++ b/emr-dynamodb-hive/pom.xml
@@ -104,7 +104,13 @@
         <dependency>
             <groupId>com.amazon.emr</groupId>
             <artifactId>shims-loader</artifactId>
-            <version>${project.version}</version>
+            <version>${project.parent.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.amazon.emr</groupId>
+            <artifactId>shims-common</artifactId>
+            <version>${project.parent.version}</version>
         </dependency>
 
     </dependencies>

--- a/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/DynamoDBExportSerDe.java
+++ b/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/DynamoDBExportSerDe.java
@@ -23,14 +23,14 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.dynamodb.DynamoDBConstants;
 import org.apache.hadoop.dynamodb.DynamoDBItemWritable;
+import org.apache.hadoop.hive.dynamodb.shims.SerDeParametersShim;
+import org.apache.hadoop.hive.dynamodb.shims.ShimsLoader;
 import org.apache.hadoop.hive.dynamodb.type.HiveDynamoDBItemType;
 import org.apache.hadoop.hive.dynamodb.type.HiveDynamoDBTypeFactory;
 import org.apache.hadoop.hive.dynamodb.util.HiveDynamoDBUtil;
 import org.apache.hadoop.hive.serde2.SerDe;
 import org.apache.hadoop.hive.serde2.SerDeException;
 import org.apache.hadoop.hive.serde2.SerDeStats;
-import org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe;
-import org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe.SerDeParameters;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
 import org.apache.hadoop.io.Text;
@@ -51,11 +51,12 @@ public class DynamoDBExportSerDe implements SerDe {
 
   private DynamoDBObjectInspector objectInspector;
   private Map<String, String> columnMappings;
-  private SerDeParameters serdeParams;
+  private SerDeParametersShim serdeParams;
 
   @Override
   public void initialize(Configuration conf, Properties tbl) throws SerDeException {
-    serdeParams = LazySimpleSerDe.initSerdeParams(conf, tbl, getClass().getName());
+    serdeParams = ShimsLoader.getHiveShims()
+        .getSerDeParametersShim(conf, tbl, getClass().getName());
     String specifiedColumnMapping = tbl.getProperty(DynamoDBConstants.DYNAMODB_COLUMN_MAPPING);
 
     for (TypeInfo type : serdeParams.getColumnTypes()) {

--- a/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/DynamoDBSerDe.java
+++ b/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/DynamoDBSerDe.java
@@ -21,6 +21,8 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.dynamodb.DynamoDBClient;
 import org.apache.hadoop.dynamodb.DynamoDBConstants;
 import org.apache.hadoop.dynamodb.DynamoDBItemWritable;
+import org.apache.hadoop.hive.dynamodb.shims.SerDeParametersShim;
+import org.apache.hadoop.hive.dynamodb.shims.ShimsLoader;
 import org.apache.hadoop.hive.dynamodb.type.HiveDynamoDBItemType;
 import org.apache.hadoop.hive.dynamodb.type.HiveDynamoDBType;
 import org.apache.hadoop.hive.dynamodb.type.HiveDynamoDBTypeFactory;
@@ -30,8 +32,6 @@ import org.apache.hadoop.hive.ql.session.SessionState.LogHelper;
 import org.apache.hadoop.hive.serde2.SerDe;
 import org.apache.hadoop.hive.serde2.SerDeException;
 import org.apache.hadoop.hive.serde2.SerDeStats;
-import org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe;
-import org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe.SerDeParameters;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.StructField;
 import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
@@ -53,13 +53,14 @@ public class DynamoDBSerDe implements SerDe {
   // user is warned exactly once
   private static boolean warningPrinted;
   private DynamoDBObjectInspector objectInspector;
-  private SerDeParameters serdeParams;
+  private SerDeParametersShim serdeParams;
   private Map<String, String> columnMappings;
   private List<String> columnNames;
 
   @Override
   public void initialize(Configuration conf, Properties tbl) throws SerDeException {
-    serdeParams = LazySimpleSerDe.initSerdeParams(conf, tbl, getClass().getName());
+    serdeParams = ShimsLoader.getHiveShims()
+        .getSerDeParametersShim(conf, tbl, getClass().getName());
     columnMappings = HiveDynamoDBUtil.getHiveToDynamoDBSchemaMapping(
         tbl.getProperty(DynamoDBConstants.DYNAMODB_COLUMN_MAPPING)
     );

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
         <aws-java-sdk.version>1.10.66</aws-java-sdk.version>
         <hadoop.version>2.7.2</hadoop.version>
         <hive1.version>1.0.0</hive1.version>
+        <hive1.2.version>1.2.1</hive1.2.version>
         <hive2.version>2.1.0</hive2.version>
         <!-- Use the more recent version as it will be more likely to
         have all the interfaces/classes we need for shims to work -->

--- a/shims/common/src/main/java/org/apache/hadoop/hive/dynamodb/shims/DynamoDbHiveShims.java
+++ b/shims/common/src/main/java/org/apache/hadoop/hive/dynamodb/shims/DynamoDbHiveShims.java
@@ -13,14 +13,21 @@
 
 package org.apache.hadoop.hive.dynamodb.shims;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.ql.index.IndexSearchCondition;
 import org.apache.hadoop.hive.ql.plan.ExprNodeDesc;
 import org.apache.hadoop.hive.ql.plan.ExprNodeGenericFuncDesc;
+import org.apache.hadoop.hive.serde2.SerDeException;
+
+import java.util.Properties;
 
 public interface DynamoDbHiveShims {
 
   ExprNodeDesc deserializeExpression(String serializedFilterExpr);
 
   ExprNodeGenericFuncDesc getIndexExpression(IndexSearchCondition condition);
+
+  SerDeParametersShim getSerDeParametersShim(Configuration configuration,
+      Properties properties, String serDeName) throws SerDeException;
 
 }

--- a/shims/common/src/main/java/org/apache/hadoop/hive/dynamodb/shims/SerDeParametersShim.java
+++ b/shims/common/src/main/java/org/apache/hadoop/hive/dynamodb/shims/SerDeParametersShim.java
@@ -1,0 +1,15 @@
+package org.apache.hadoop.hive.dynamodb.shims;
+
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
+
+import java.util.List;
+
+public interface SerDeParametersShim {
+
+  List<String> getColumnNames();
+
+  List<TypeInfo> getColumnTypes();
+
+  byte[] getSeparators();
+
+}

--- a/shims/hive1-shims/pom.xml
+++ b/shims/hive1-shims/pom.xml
@@ -22,6 +22,11 @@
             <version>${hive1.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-common</artifactId>
+            <version>${hadoop.version}</version>
+        </dependency>
+        <dependency>
             <groupId>com.amazon.emr</groupId>
             <artifactId>shims-common</artifactId>
             <version>${project.parent.version}</version>

--- a/shims/hive1-shims/src/main/java/org/apache/hadoop/hive/dynamodb/shims/DynamoDbHive1Shims.java
+++ b/shims/hive1-shims/src/main/java/org/apache/hadoop/hive/dynamodb/shims/DynamoDbHive1Shims.java
@@ -13,10 +13,14 @@
 
 package org.apache.hadoop.hive.dynamodb.shims;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.ql.exec.Utilities;
 import org.apache.hadoop.hive.ql.index.IndexSearchCondition;
 import org.apache.hadoop.hive.ql.plan.ExprNodeDesc;
 import org.apache.hadoop.hive.ql.plan.ExprNodeGenericFuncDesc;
+import org.apache.hadoop.hive.serde2.SerDeException;
+
+import java.util.Properties;
 
 final class DynamoDbHive1Shims implements DynamoDbHiveShims {
 
@@ -34,6 +38,12 @@ final class DynamoDbHive1Shims implements DynamoDbHiveShims {
   @Override
   public ExprNodeGenericFuncDesc getIndexExpression(IndexSearchCondition condition) {
     return condition.getComparisonExpr();
+  }
+
+  @Override
+  public SerDeParametersShim getSerDeParametersShim(Configuration configuration,
+      Properties properties, String serDeName) throws SerDeException {
+    return new Hive1SerDeParametersShim(configuration, properties, serDeName);
   }
 
 }

--- a/shims/hive1-shims/src/main/java/org/apache/hadoop/hive/dynamodb/shims/Hive1SerDeParametersShim.java
+++ b/shims/hive1-shims/src/main/java/org/apache/hadoop/hive/dynamodb/shims/Hive1SerDeParametersShim.java
@@ -1,0 +1,36 @@
+package org.apache.hadoop.hive.dynamodb.shims;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.serde2.SerDeException;
+import org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe;
+import org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe.SerDeParameters;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
+
+import java.util.List;
+import java.util.Properties;
+
+class Hive1SerDeParametersShim implements SerDeParametersShim {
+
+  private final SerDeParameters realSerDeParameters;
+
+  Hive1SerDeParametersShim(Configuration configuration, Properties properties, String serDeName)
+      throws SerDeException {
+    this.realSerDeParameters = LazySimpleSerDe.initSerdeParams(configuration, properties,
+        serDeName);
+  }
+
+  @Override
+  public List<String> getColumnNames() {
+    return this.realSerDeParameters.getColumnNames();
+  }
+
+  @Override
+  public List<TypeInfo> getColumnTypes() {
+    return this.realSerDeParameters.getColumnTypes();
+  }
+
+  @Override
+  public byte[] getSeparators() {
+    return this.realSerDeParameters.getSeparators();
+  }
+}

--- a/shims/hive1.2-shims/pom.xml
+++ b/shims/hive1.2-shims/pom.xml
@@ -9,24 +9,37 @@
         <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>shims-common</artifactId>
+    <artifactId>hive1.2-shims</artifactId>
     <packaging>jar</packaging>
 
-    <name>ShimsCommon</name>
-    <description>Common shim interface</description>
+    <name>Hive1.2Shims</name>
+    <description>Shims for Hive-1.2.x compatibility</description>
 
     <dependencies>
-
         <dependency>
             <groupId>org.apache.hive</groupId>
             <artifactId>hive-exec</artifactId>
-            <version>${hive.version}</version>
+            <version>${hive1.2.version}</version>
         </dependency>
-
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
             <version>${hadoop.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.amazon.emr</groupId>
+            <artifactId>shims-common</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.amazon.emr</groupId>
+            <artifactId>hive1-shims</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.amazon.emr</groupId>
+            <artifactId>hive2-shims</artifactId>
+            <version>${project.parent.version}</version>
         </dependency>
     </dependencies>
 

--- a/shims/hive1.2-shims/src/main/java/org/apache/hadoop/hive/dynamodb/shims/DynamoDbHive1Dot2Shims.java
+++ b/shims/hive1.2-shims/src/main/java/org/apache/hadoop/hive/dynamodb/shims/DynamoDbHive1Dot2Shims.java
@@ -1,0 +1,42 @@
+package org.apache.hadoop.hive.dynamodb.shims;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.ql.index.IndexSearchCondition;
+import org.apache.hadoop.hive.ql.plan.ExprNodeDesc;
+import org.apache.hadoop.hive.ql.plan.ExprNodeGenericFuncDesc;
+import org.apache.hadoop.hive.serde2.SerDeException;
+
+import java.util.Properties;
+
+class DynamoDbHive1Dot2Shims implements DynamoDbHiveShims {
+
+  private static final String HIVE_1_2_VERSION = "1.2";
+  DynamoDbHiveShims hive1Shims;
+
+  DynamoDbHive1Dot2Shims() {
+    this.hive1Shims = new DynamoDbHive1Shims();
+  }
+
+  @Override
+  public ExprNodeDesc deserializeExpression(String serializedFilterExpr) {
+    return hive1Shims.deserializeExpression(serializedFilterExpr);
+  }
+
+  @Override
+  public ExprNodeGenericFuncDesc getIndexExpression(IndexSearchCondition condition) {
+    return condition.getComparisonExpr();
+  }
+
+  /**
+   * Hive 1.2.x and Hive 2.x share behavior for SerDeParameters class initialization.
+   */
+  @Override
+  public SerDeParametersShim getSerDeParametersShim(Configuration configuration,
+      Properties properties, String serDeName) throws SerDeException {
+    return new Hive2SerDeParametersShim(configuration, properties, serDeName);
+  }
+
+  static boolean supportsVersion(String version) {
+    return version.startsWith(HIVE_1_2_VERSION);
+  }
+}

--- a/shims/hive2-shims/src/main/java/org/apache/hadoop/hive/dynamodb/shims/DynamoDbHive2Shims.java
+++ b/shims/hive2-shims/src/main/java/org/apache/hadoop/hive/dynamodb/shims/DynamoDbHive2Shims.java
@@ -13,10 +13,14 @@
 
 package org.apache.hadoop.hive.dynamodb.shims;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.ql.exec.SerializationUtilities;
 import org.apache.hadoop.hive.ql.index.IndexSearchCondition;
 import org.apache.hadoop.hive.ql.plan.ExprNodeDesc;
 import org.apache.hadoop.hive.ql.plan.ExprNodeGenericFuncDesc;
+import org.apache.hadoop.hive.serde2.SerDeException;
+
+import java.util.Properties;
 
 final class DynamoDbHive2Shims implements DynamoDbHiveShims {
 
@@ -34,6 +38,15 @@ final class DynamoDbHive2Shims implements DynamoDbHiveShims {
   @Override
   public ExprNodeGenericFuncDesc getIndexExpression(IndexSearchCondition condition) {
     return condition.getIndexExpr();
+  }
+
+  /**
+   * Hive 1.2 and Hive 2.x share SerDeParameters implementations, so we can delegate to that shim.
+   */
+  @Override
+  public SerDeParametersShim getSerDeParametersShim(Configuration configuration,
+      Properties properties, String serDeName) throws SerDeException {
+    return new Hive2SerDeParametersShim(configuration, properties, serDeName);
   }
 
 }

--- a/shims/hive2-shims/src/main/java/org/apache/hadoop/hive/dynamodb/shims/Hive2SerDeParametersShim.java
+++ b/shims/hive2-shims/src/main/java/org/apache/hadoop/hive/dynamodb/shims/Hive2SerDeParametersShim.java
@@ -1,0 +1,34 @@
+package org.apache.hadoop.hive.dynamodb.shims;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.serde2.SerDeException;
+import org.apache.hadoop.hive.serde2.lazy.LazySerDeParameters;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
+
+import java.util.List;
+import java.util.Properties;
+
+class Hive2SerDeParametersShim implements SerDeParametersShim {
+
+  private final LazySerDeParameters realSerDeParameters;
+
+  Hive2SerDeParametersShim(Configuration configuration, Properties properties, String serDeName)
+      throws SerDeException {
+    this.realSerDeParameters = new LazySerDeParameters(configuration, properties, serDeName);
+  }
+
+  @Override
+  public List<String> getColumnNames() {
+    return this.realSerDeParameters.getColumnNames();
+  }
+
+  @Override
+  public List<TypeInfo> getColumnTypes() {
+    return this.realSerDeParameters.getColumnTypes();
+  }
+
+  @Override
+  public byte[] getSeparators() {
+    return this.realSerDeParameters.getSeparators();
+  }
+}

--- a/shims/loader/pom.xml
+++ b/shims/loader/pom.xml
@@ -37,6 +37,16 @@
             <artifactId>shims-common</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.amazon.emr</groupId>
+            <artifactId>hive1-shims</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.amazon.emr</groupId>
+            <artifactId>hive1.2-shims</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/shims/loader/src/main/java/org/apache/hadoop/hive/dynamodb/shims/ShimsLoader.java
+++ b/shims/loader/src/main/java/org/apache/hadoop/hive/dynamodb/shims/ShimsLoader.java
@@ -40,13 +40,19 @@ public final class ShimsLoader {
       try {
         return DynamoDbHive1Shims.class.newInstance();
       } catch (InstantiationException | IllegalAccessException e) {
-        throw new RuntimeException("unable to get instance of hive 1 shim class");
+        throw new RuntimeException("unable to get instance of Hive 1.x shim class");
+      }
+    } else if (DynamoDbHive1Dot2Shims.supportsVersion(hiveVersion)) {
+      try {
+        return DynamoDbHive1Dot2Shims.class.newInstance();
+      } catch (InstantiationException | IllegalAccessException e) {
+        throw new RuntimeException("unable to get instance of Hive 1.2.x shim class");
       }
     } else if (DynamoDbHive2Shims.supportsVersion(hiveVersion)) {
       try {
         return DynamoDbHive2Shims.class.newInstance();
       } catch (InstantiationException | IllegalAccessException e) {
-        throw new RuntimeException("unable to get instance of hive 2 shim class");
+        throw new RuntimeException("unable to get instance of Hive 2.x shim class");
       }
     } else {
       throw new RuntimeException("Shim class for Hive version " + hiveVersion + " does not exist");

--- a/shims/loader/test/main/java/org/apache/hadoop/hive/dynamodb/shims/ShimsLoaderTest.java
+++ b/shims/loader/test/main/java/org/apache/hadoop/hive/dynamodb/shims/ShimsLoaderTest.java
@@ -32,6 +32,8 @@ public class ShimsLoaderTest {
 
   private static final String HIVE_1_VERSION = "1.0.0";
 
+  private static final String HIVE_1_2_VERSION = "1.2.0";
+
   private static final String HIVE_2_VERSION = "2.1.0";
 
   @Before
@@ -45,24 +47,28 @@ public class ShimsLoaderTest {
   }
 
   @Test
+  public void hive1Dot2ShimsClassSupportsCorrectVersion() {
+    assertTrue(DynamoDbHive1Dot2Shims.supportsVersion(HIVE_1_2_VERSION));
+  }
+
+  @Test
   public void hive1ShimsClassSupportsCorrectVersion() {
     assertTrue(DynamoDbHive1Shims.supportsVersion(HIVE_1_VERSION));
   }
 
   @Test
   public void returnsCorrectShimsImplementationForHive2() {
-    when(HiveVersionInfo.getShortVersion()).thenReturn(HIVE_2_VERSION);
-    DynamoDbHiveShims shims = ShimsLoader.getHiveShims();
-    assertTrue(shims instanceof DynamoDbHive2Shims);
-    ShimsLoader.clearShimClass();
+    assertGetsCorrectShimsClassForVersion(DynamoDbHive2Shims.class, HIVE_2_VERSION);
+  }
+
+  @Test
+  public void returnsCorrectShimsImplementationForHive1Dot2() {
+    assertGetsCorrectShimsClassForVersion(DynamoDbHive1Dot2Shims.class, HIVE_1_2_VERSION);
   }
 
   @Test
   public void returnsCorrectShimsImplementationForHive1() {
-    when(HiveVersionInfo.getShortVersion()).thenReturn(HIVE_1_VERSION);
-    DynamoDbHiveShims shims = ShimsLoader.getHiveShims();
-    assertTrue(shims instanceof DynamoDbHive1Shims);
-    ShimsLoader.clearShimClass();
+    assertGetsCorrectShimsClassForVersion(DynamoDbHive1Shims.class, HIVE_1_VERSION);
   }
 
   @Test(expected = RuntimeException.class)
@@ -70,6 +76,13 @@ public class ShimsLoaderTest {
     when(HiveVersionInfo.getShortVersion()).thenReturn("this.is.not.a.real.hive.version");
     ShimsLoader.clearShimClass();
     ShimsLoader.getHiveShims();
+  }
+
+  private void assertGetsCorrectShimsClassForVersion(Class expectedClass, String version) {
+    when(HiveVersionInfo.getShortVersion()).thenReturn(version);
+    DynamoDbHiveShims shims = ShimsLoader.getHiveShims();
+    assertTrue(expectedClass.isInstance(shims));
+    ShimsLoader.clearShimClass();
   }
 
 }

--- a/shims/pom.xml
+++ b/shims/pom.xml
@@ -13,11 +13,12 @@
     <packaging>pom</packaging>
 
     <name>EMRDynamoDBConnectorShims</name>
-    <description>Shims for Hive 1.x/2.x compatibility</description>
+    <description>Shims for Hive 1.0/1.2/2.0 compatibility</description>
 
     <modules>
         <module>common</module>
         <module>hive1-shims</module>
+        <module>hive1.2-shims</module>
         <module>hive2-shims</module>
         <module>loader</module>
     </modules>


### PR DESCRIPTION
Originally the Shim layer consisted of only two method calls which
differed between hive 1.x and hive 2.x. Unfortunately, Hive 1.2.x
makes use of the LazySerDeParameters constructor as opposed to the
"older" LazySimpleSerDe.initSerdeParams() static factory method.

This change introduces a SerDeParameterShim class to help delegate
this usage depending on the detected runtime Hive version, and
utilizes the original shim logic to do so.