### PR TITLE
Make Hadoop 'provided' to support Hive 1.0.0

### DIFF
--- a/emr-dynamodb-hive/pom.xml
+++ b/emr-dynamodb-hive/pom.xml
@@ -70,8 +70,6 @@
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
             <version>${hadoop.version}</version>
-            <type>test-jar</type>
-            <scope>test</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
 Hive 1.0.0 doesn't bring in some classes that are normally
 brought in when building against Hive 1.2.1 or Hive 2.0.0.
 This change returns hadoop-common to the project-default
 'provided' scope in order to allow building against Hive
 1.0.0 to work correctly.