### PR TITLE
Make DynamoDBItemWritable implement Serializable

### DIFF
--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBItemWritable.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBItemWritable.java
@@ -23,11 +23,12 @@ import org.apache.hadoop.io.Writable;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.io.Serializable;
 import java.lang.reflect.Type;
 import java.util.HashMap;
 import java.util.Map;
 
-public class DynamoDBItemWritable implements Writable {
+public class DynamoDBItemWritable implements Writable, Serializable {
 
   public static final Type type = new TypeToken<Map<String, AttributeValue>>() {}.getType();
 


### PR DESCRIPTION
This fixes: https://github.com/awslabs/emr-dynamodb-connector/issues/13

This patch makes DynamoDBItemWritable implement Serializable because pyspark requires that a writeObject implements Serializable [1].
  
[1] https://github.com/apache/spark/blob/v2.1.0/core/src/main/scala/org/apache/spark/serializer/JavaSerializer.scala#L45