### PR TITLE
Null check ScanResult#getConsumedCapacity()

### DIFF
--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/preader/ScanRecordReadRequest.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/preader/ScanRecordReadRequest.java
@@ -43,7 +43,11 @@ public class ScanRecordReadRequest extends AbstractRecordReadRequest {
     ScanResult result = retryResult.result;
     int retries = retryResult.retries;
 
-    return new PageResults<>(result.getItems(), result.getLastEvaluatedKey(), result
-        .getConsumedCapacity().getCapacityUnits(), retries);
+    double consumedCapacityUnits = 0.0;
+    if (result.getConsumedCapacity() != null) {
+      consumedCapacityUnits = result.getConsumedCapacity().getCapacityUnits();
+    }
+    return new PageResults<>(result.getItems(), result.getLastEvaluatedKey(), consumedCapacityUnits,
+        retries);
   }
 }

--- a/emr-dynamodb-hadoop/src/test/java/org/apache/hadoop/dynamodb/preader/ScanRecordReadRequestTest.java
+++ b/emr-dynamodb-hadoop/src/test/java/org/apache/hadoop/dynamodb/preader/ScanRecordReadRequestTest.java
@@ -1,0 +1,65 @@
+package org.apache.hadoop.dynamodb.preader;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.when;
+
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import com.amazonaws.services.dynamodbv2.model.ScanResult;
+
+import org.apache.hadoop.dynamodb.DynamoDBClient;
+import org.apache.hadoop.dynamodb.DynamoDBFibonacciRetryer.RetryResult;
+import org.apache.hadoop.dynamodb.filter.DynamoDBQueryFilter;
+import org.apache.hadoop.dynamodb.preader.RateController.RequestLimit;
+import org.apache.hadoop.dynamodb.split.DynamoDBSegmentsSplit;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.Reporter;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RunWith(MockitoJUnitRunner.class)
+public final class ScanRecordReadRequestTest {
+
+  @Mock
+  DynamoDBRecordReaderContext context;
+  @Mock
+  DynamoDBClient client;
+
+  @Test
+  public void fetchPageReturnsZeroConsumedCapacityWhenResultsConsumedCapacityIsNull() {
+    RetryResult stubbedResult = new RetryResult<>(new ScanResult().withConsumedCapacity(null)
+        .withItems(new HashMap<String, AttributeValue>()), 0);
+    stubScanTableWith(stubbedResult);
+
+    when(context.getClient()).thenReturn(client);
+    when(context.getConf()).thenReturn(new JobConf());
+    when(context.getSplit()).thenReturn(new DynamoDBSegmentsSplit());
+    ScanReadManager readManager = Mockito.mock(ScanReadManager.class);
+    ScanRecordReadRequest readRequest = new ScanRecordReadRequest(readManager, context, 0, null);
+    PageResults<Map<String, AttributeValue>> pageResults =
+        readRequest.fetchPage(new RequestLimit(0, 0));
+    assertEquals(0.0, pageResults.consumedRcu, 0.0);
+  }
+
+  private void stubScanTableWith(RetryResult<ScanResult> scanResultRetryResult) {
+    when(client.scanTable(
+        anyString(),
+        any(DynamoDBQueryFilter.class),
+        anyInt(),
+        anyInt(),
+        any(Map.class),
+        anyLong(),
+        any(Reporter.class))
+    ).thenReturn(scanResultRetryResult);
+  }
+
+}


### PR DESCRIPTION
 Per http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.UsageNotes.html
 ScanResult#getConsumedCapacity() returns null for operation
 responses against a DynamoDBLocal instance. This was resulting in NPEs
 for users developing against a local instance.

 This fixes: https://github.com/awslabs/emr-dynamodb-connector/issues/11