### PR TITLE
Split up max item/batch sizes & make them configurable

### DIFF
--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBConstants.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBConstants.java
@@ -58,6 +58,15 @@ public interface DynamoDBConstants {
   String MAX_MAP_TASKS = "dynamodb.max.map.tasks";
   String DEFAULT_THROUGHPUT_PERCENTAGE = "0.5";
 
+  String MAX_ITEM_SIZE = "dynamodb.max.item.size";
+  String MAX_BATCH_SIZE = "dynamodb.max.batch.size";
+  String MAX_ITEMS_PER_BATCH = "dynamodb.max.batch.items";
+
+  // http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Limits.html
+  long DEFAULT_MAX_ITEM_SIZE = 400 * 1024;
+  long DEFAULT_MAX_BATCH_SIZE = 16 * 1024 * 1024;
+  long DEFAULT_MAX_ITEMS_PER_BATCH = 25;
+
   double READ_EVENTUALLY_TO_STRONGLY_CONSISTENT_FACTOR = 2;
 
   String SCAN_SEGMENTS = "dynamodb.scan.segments";

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBUtil.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBUtil.java
@@ -13,6 +13,9 @@
 
 package org.apache.hadoop.dynamodb;
 
+import static org.apache.hadoop.dynamodb.DynamoDBConstants.DEFAULT_MAX_ITEMS_PER_BATCH;
+import static org.apache.hadoop.dynamodb.DynamoDBConstants.MAX_ITEMS_PER_BATCH;
+
 import com.google.common.base.Strings;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -185,6 +188,11 @@ public final class DynamoDBUtil {
       }
     }
     return byteSize;
+  }
+
+  static long getBoundedBatchLimit(Configuration config, long batchSize) {
+    long maxItemsPerBatch = config.getLong(MAX_ITEMS_PER_BATCH, DEFAULT_MAX_ITEMS_PER_BATCH);
+    return Math.min(Math.max(batchSize, 1), maxItemsPerBatch);
   }
 
   public static String getValueFromConf(Configuration conf, String confKey, String defaultValue) {

--- a/emr-dynamodb-hadoop/src/test/java/org/apache/hadoop/dynamodb/DynamoDBUtilTest.java
+++ b/emr-dynamodb-hadoop/src/test/java/org/apache/hadoop/dynamodb/DynamoDBUtilTest.java
@@ -13,6 +13,8 @@
 
 package org.apache.hadoop.dynamodb;
 
+import static org.apache.hadoop.dynamodb.DynamoDBConstants.DEFAULT_MAX_ITEMS_PER_BATCH;
+import static org.apache.hadoop.dynamodb.DynamoDBUtil.getBoundedBatchLimit;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -129,4 +131,13 @@ public class DynamoDBUtilTest {
     RegionUtils.getRegion(DynamoDBConstants.DEFAULT_AWS_REGION);
   }
 
+  @Test
+  public void testGetBoundedBatchLimit() {
+    assertEquals(1, getBoundedBatchLimit(conf, 0));
+    assertEquals(1, getBoundedBatchLimit(conf, 1));
+    assertEquals(DEFAULT_MAX_ITEMS_PER_BATCH,
+        getBoundedBatchLimit(conf, DEFAULT_MAX_ITEMS_PER_BATCH + 1));
+    assertEquals(DEFAULT_MAX_ITEMS_PER_BATCH,
+        getBoundedBatchLimit(conf, DEFAULT_MAX_ITEMS_PER_BATCH));
+  }
 }


### PR DESCRIPTION
The DynamoDB client has historically been using only a single constant to
limit the maximum size of an item that can be stored in DynamoDB using the
connector. This is incorrect/inefficient as it doesn't truly reflect the
limits imposed by the DynamoDB service.

DynamoDB enforces two separate limits:

  1. A single item cannot exceed 400KB
  2. An entire request in a Batch(Get/Write)Item request/response cannot
     exceed 16MB

This change splits up the original logic to ensure that each of these
limits are enforced separately, and ensures that batch writes in particular
aren't capped at 512KB as they have been originally.

This change also makes three different values configurable:

  1. Max item size: "dynamodb.item.max.size" (default: 400KB)
  2. Max batch request/response size: "dynamodb.batch.max.size" (default: 16MB)
  3. Max tems per batch: "dynamodb.batch.max.items" (default: 25)

 This fixes: https://github.com/awslabs/emr-dynamodb-connector/issues/10