### PR TITLE
Bump AWS Java SDK to 1.11.129, Hadoop to 2.7.3, and Hive2 to 2.1.1.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This simple tool that makes use of the InputFormat and OutputFormat implementati
  way to import to and export data from DynamoDB.
 
 ### Supported Versions
-Currently the project builds against Hive 2.1.0, 1.2.1, and 1.0.0. Set this by using the `hive1.version`,
+Currently the project builds against Hive 2.1.1, 1.2.1, and 1.0.0. Set this by using the `hive1.version`,
 `hive1.2.version and `hive2.version` properties in the root Maven `pom.xml`, respectively.
 
 ## How to Build

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/util/ClusterTopologyNodeCapacityProvider.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/util/ClusterTopologyNodeCapacityProvider.java
@@ -13,10 +13,8 @@
 
 package org.apache.hadoop.dynamodb.util;
 
-import com.amazonaws.util.json.JSONArray;
-import com.amazonaws.util.json.JSONException;
-import com.amazonaws.util.json.JSONObject;
-
+import com.amazonaws.util.json.Jackson;
+import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.mapred.JobConf;
@@ -105,16 +103,15 @@ public class ClusterTopologyNodeCapacityProvider implements NodeCapacityProvider
     return new String(Files.readAllBytes(Paths.get("/mnt/var/lib/info/job-flow.json")));
   }
 
-  private String extractInstanceType(String jobFlowJsonString, String targetInstanceRole) throws
-      JSONException {
-    JSONObject jobFlowJson = new JSONObject(jobFlowJsonString);
-    JSONArray instanceGroups = jobFlowJson.getJSONArray("instanceGroups");
+  private String extractInstanceType(String jobFlowJsonString, String targetInstanceRole) {
+    JsonNode jobFlowJson = Jackson.jsonNodeOf(jobFlowJsonString);
+    JsonNode instanceGroups = jobFlowJson.get("instanceGroups");
 
-    for (int i = 0; i < instanceGroups.length(); i++) {
-      JSONObject instanceGroup = instanceGroups.getJSONObject(i);
-      String instanceRole = instanceGroup.getString("instanceRole");
+    for (int i = 0; i < instanceGroups.size(); i++) {
+      JsonNode instanceGroup = instanceGroups.get(i);
+      String instanceRole = instanceGroup.get("instanceRole").asText();
       if (targetInstanceRole.equalsIgnoreCase(instanceRole)) {
-        String instanceType = instanceGroup.getString("instanceType");
+        String instanceType = instanceGroup.get("instanceType").asText();
         log.info(instanceRole + " instance type: " + instanceType);
         return instanceType;
       }

--- a/pom.xml
+++ b/pom.xml
@@ -22,11 +22,11 @@
 
     <properties>
         <java.version>1.7</java.version>
-        <aws-java-sdk.version>1.10.77</aws-java-sdk.version>
-        <hadoop.version>2.7.2</hadoop.version>
+        <aws-java-sdk.version>1.11.129</aws-java-sdk.version>
+        <hadoop.version>2.7.3</hadoop.version>
         <hive1.version>1.0.0</hive1.version>
         <hive1.2.version>1.2.1</hive1.2.version>
-        <hive2.version>2.1.0</hive2.version>
+        <hive2.version>2.1.1</hive2.version>
         <!-- Use the more recent version as it will be more likely to
         have all the interfaces/classes we need for shims to work -->
         <hive.version>${hive2.version}</hive.version>


### PR DESCRIPTION
Modifies ClusterTopologyNodeCapacityProvider to use Jackson instead of deprecated json.org in 1.11.x of the AWS Java SDK.