### PR TITLE
Fix compatibility with Hive 2.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This simple tool that makes use of the InputFormat and OutputFormat implementati
  way to import to and export data from DynamoDB.
 
 ### Supported Versions
-Currently the project builds against Hive 2.1.1, 1.2.1, and 1.0.0. Set this by using the `hive1.version`,
+Currently the project builds against Hive 2.3.0, 1.2.1, and 1.0.0. Set this by using the `hive1.version`,
 `hive1.2.version and `hive2.version` properties in the root Maven `pom.xml`, respectively.
 
 ## How to Build

--- a/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/DynamoDBExportSerDe.java
+++ b/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/DynamoDBExportSerDe.java
@@ -28,7 +28,7 @@ import org.apache.hadoop.hive.dynamodb.shims.ShimsLoader;
 import org.apache.hadoop.hive.dynamodb.type.HiveDynamoDBItemType;
 import org.apache.hadoop.hive.dynamodb.type.HiveDynamoDBTypeFactory;
 import org.apache.hadoop.hive.dynamodb.util.HiveDynamoDBUtil;
-import org.apache.hadoop.hive.serde2.SerDe;
+import org.apache.hadoop.hive.serde2.AbstractSerDe;
 import org.apache.hadoop.hive.serde2.SerDeException;
 import org.apache.hadoop.hive.serde2.SerDeStats;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
@@ -45,7 +45,7 @@ import java.util.Properties;
  * This class is used to read the DynanmoDB backup format and allow querying individual columns from
  * the schemaless backup.
  */
-public class DynamoDBExportSerDe implements SerDe {
+public class DynamoDBExportSerDe extends AbstractSerDe {
 
   private static final Log log = LogFactory.getLog(DynamoDBExportSerDe.class);
 

--- a/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/DynamoDBSerDe.java
+++ b/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/DynamoDBSerDe.java
@@ -29,7 +29,7 @@ import org.apache.hadoop.hive.dynamodb.type.HiveDynamoDBTypeFactory;
 import org.apache.hadoop.hive.dynamodb.util.HiveDynamoDBUtil;
 import org.apache.hadoop.hive.ql.session.SessionState;
 import org.apache.hadoop.hive.ql.session.SessionState.LogHelper;
-import org.apache.hadoop.hive.serde2.SerDe;
+import org.apache.hadoop.hive.serde2.AbstractSerDe;
 import org.apache.hadoop.hive.serde2.SerDeException;
 import org.apache.hadoop.hive.serde2.SerDeStats;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
@@ -46,7 +46,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
-public class DynamoDBSerDe implements SerDe {
+public class DynamoDBSerDe extends AbstractSerDe {
 
   private static final Log log = LogFactory.getLog(DynamoDBSerDe.class);
   // Hive initializes SerDe multiple times and we need to make sure that the

--- a/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/DynamoDBStorageHandler.java
+++ b/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/DynamoDBStorageHandler.java
@@ -44,7 +44,7 @@ import org.apache.hadoop.hive.ql.plan.TableDesc;
 import org.apache.hadoop.hive.ql.security.authorization.DefaultHiveAuthorizationProvider;
 import org.apache.hadoop.hive.ql.security.authorization.HiveAuthorizationProvider;
 import org.apache.hadoop.hive.serde2.Deserializer;
-import org.apache.hadoop.hive.serde2.SerDe;
+import org.apache.hadoop.hive.serde2.AbstractSerDe;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapred.InputFormat;
 import org.apache.hadoop.mapred.JobConf;
@@ -208,7 +208,7 @@ public class DynamoDBStorageHandler implements HiveMetaHook, HiveStoragePredicat
   }
 
   @Override
-  public Class<? extends SerDe> getSerDeClass() {
+  public Class<? extends AbstractSerDe> getSerDeClass() {
     return DynamoDBSerDe.class;
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,11 +22,11 @@
 
     <properties>
         <java.version>1.7</java.version>
-        <aws-java-sdk.version>1.11.129</aws-java-sdk.version>
+        <aws-java-sdk.version>1.11.160</aws-java-sdk.version>
         <hadoop.version>2.7.3</hadoop.version>
         <hive1.version>1.0.0</hive1.version>
         <hive1.2.version>1.2.1</hive1.2.version>
-        <hive2.version>2.1.1</hive2.version>
+        <hive2.version>2.3.0</hive2.version>
         <!-- Use the more recent version as it will be more likely to
         have all the interfaces/classes we need for shims to work -->
         <hive.version>${hive2.version}</hive.version>

--- a/shims/hive2-shims/src/main/java/org/apache/hadoop/hive/dynamodb/shims/DynamoDbHive2Shims.java
+++ b/shims/hive2-shims/src/main/java/org/apache/hadoop/hive/dynamodb/shims/DynamoDbHive2Shims.java
@@ -24,7 +24,7 @@ import java.util.Properties;
 
 final class DynamoDbHive2Shims implements DynamoDbHiveShims {
 
-  private static final String HIVE_2_VERSION = "2.1.0";
+  private static final String HIVE_2_VERSION = "2.3.0";
 
   static boolean supportsVersion(String version) {
     return version.startsWith(HIVE_2_VERSION);


### PR DESCRIPTION
The SerDe interface was removed in Hive 2.3.0: https://issues.apache.org/jira/browse/HIVE-15167

This changes all instances of 'SerDe' to 'AbstractSerDe' to address.

Also update pom and Hive2Shims to reflect updated versions of Hive and AWS Java SDK.