### PR TITLE
Null check on result.getConsumedCapacity()

### DIFF
--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/write/AbstractDynamoDBRecordWriter.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/write/AbstractDynamoDBRecordWriter.java
@@ -112,9 +112,11 @@ public abstract class AbstractDynamoDBRecordWriter<K, V> implements RecordWriter
     totolItemsWritten++;
 
     if (result != null) {
-      for (ConsumedCapacity consumedCapacity : result.getConsumedCapacity()) {
-        double consumedUnits = consumedCapacity.getCapacityUnits();
-        totalIOPSConsumed += consumedUnits;
+      if (result.getConsumedCapacity() != null) {
+        for (ConsumedCapacity consumedCapacity : result.getConsumedCapacity()) {
+          double consumedUnits = consumedCapacity.getCapacityUnits();
+          totalIOPSConsumed += consumedUnits;
+        }
       }
 
       int unprocessedItems = 0;


### PR DESCRIPTION
Existing code assumes a response from DynamoDB includes a "consumed capacity" property (since it's requested).  However, it appears that the local (non-hosted) version of DynamoDB which is made available for testing purposes does not return the property, even when requested.  As such, a NPE can occur here.

This will likely affect the function of the IOPSController, since we cannot update the consumed units, but I suspect it doesn't matter in the local DynamoDB case, since there are no actual capacity controls.