### PR TITLE
Add parametrized constructor for DynamoDBItemWritable

### DIFF
--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBItemWritable.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBItemWritable.java
@@ -42,7 +42,15 @@ public class DynamoDBItemWritable implements Writable, Serializable {
   private static final char FIRST_MAGIC_BYTES = 0x0001;
   private static final byte NEXT_MAGIC_BYTE = 0x00;
 
-  private Map<String, AttributeValue> dynamoDBItem = new HashMap<>();
+  private Map<String, AttributeValue> dynamoDBItem;
+
+  public DynamoDBItemWritable() {
+    dynamoDBItem = new HashMap<>();
+  }
+
+  public DynamoDBItemWritable(Map<String, AttributeValue> dynamoDBItem) {
+    this.dynamoDBItem = dynamoDBItem;
+  }
 
   // Remember: By changing this method, you change how items are serialized
   // to disk, including for backups in S3. At least the read method needs to

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/read/AbstractDynamoDBRecordReader.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/read/AbstractDynamoDBRecordReader.java
@@ -130,8 +130,7 @@ public abstract class AbstractDynamoDBRecordReader<K, V> implements RecordReader
   }
 
   protected void convertDynamoDBItemToValue(Map<String, AttributeValue> item, V value) {
-    DynamoDBItemWritable ddbItem = new DynamoDBItemWritable();
-    ddbItem.setItem(item);
+    DynamoDBItemWritable ddbItem = new DynamoDBItemWritable(item);
     convertDynamoDBItemToValue(ddbItem, value);
   }
 

--- a/emr-dynamodb-hadoop/src/test/java/org/apache/hadoop/dynamodb/DynamoDBItemWritableTest.java
+++ b/emr-dynamodb-hadoop/src/test/java/org/apache/hadoop/dynamodb/DynamoDBItemWritableTest.java
@@ -196,4 +196,11 @@ public class DynamoDBItemWritableTest {
 
     item.setItem(sampleData);
   }
+
+  @Test
+  public void testParametrizedConstructor() {
+    Map<String, AttributeValue> map = new HashMap<>();
+    DynamoDBItemWritable item = new DynamoDBItemWritable(map);
+    assertEquals(item.getItem(), map);
+  }
 }

--- a/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/DynamoDBExportSerDe.java
+++ b/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/DynamoDBExportSerDe.java
@@ -116,8 +116,7 @@ public class DynamoDBExportSerDe extends AbstractSerDe {
         item.put(dynamoDBAttributeName, deserializedAttributeValue);
       }
 
-      DynamoDBItemWritable dynamoDBItem = new DynamoDBItemWritable();
-      dynamoDBItem.setItem(item);
+      DynamoDBItemWritable dynamoDBItem = new DynamoDBItemWritable(item);
       return dynamoDBItem;
     } else {
       throw new SerDeException(getClass().toString() + ": expects Text object!");

--- a/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/DynamoDBSerDe.java
+++ b/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/DynamoDBSerDe.java
@@ -152,8 +152,7 @@ public class DynamoDBSerDe extends AbstractSerDe {
       }
     }
 
-    DynamoDBItemWritable itemWritable = new DynamoDBItemWritable();
-    itemWritable.setItem(item);
+    DynamoDBItemWritable itemWritable = new DynamoDBItemWritable(item);
     return itemWritable;
   }
 


### PR DESCRIPTION
Added a constructor to take dynamoDBItemMap as an argument. Refactored the code to create dynamoDBItemMap(HashMap) only when initialized with no args constructor.

This pull request is pretty simple and not related to any issue, but can be useful for the users.

Attached Tests Snippet
[test_snippet.txt](https://github.com/awslabs/emr-dynamodb-connector/files/2313921/test_snippet.txt)
