### PR TITLE
Add support for Tables using On-Demand billing mode

### DIFF
--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBBillingMode.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBBillingMode.java
@@ -1,0 +1,5 @@
+package org.apache.hadoop.dynamodb;
+
+public enum DynamoDBBillingMode {
+    PROVISIONED, PAY_PER_REQUEST
+}

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBConstants.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBConstants.java
@@ -52,6 +52,8 @@ public interface DynamoDBConstants {
   String THROUGHPUT_READ_PERCENT = "dynamodb.throughput.read.percent";
   String READ_THROUGHPUT = "dynamodb.throughput.read";
   String WRITE_THROUGHPUT = "dynamodb.throughput.write";
+  String MAX_ON_DEMAND_WRITE_THROUGHPUT = "dynamodb.max.ondemand.write.throughput";
+  String MAX_ON_DEMAND_READ_THROUGHPUT = "dynamodb.max.ondemand.read.throughput";
   String AVG_ITEM_SIZE = "dynamodb.item.average.size";
   String ITEM_COUNT = "dynamodb.item.count";
   String TABLE_SIZE_BYTES = "dynamodb.table.size-bytes";

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     </licenses>
     <properties>
         <java.version>1.7</java.version>
-        <aws-java-sdk.version>1.11.160</aws-java-sdk.version>
+        <aws-java-sdk.version>1.11.472</aws-java-sdk.version>
         <hadoop.version>2.7.3</hadoop.version>
         <hive1.version>1.0.0</hive1.version>
         <hive1.2.version>1.2.1</hive1.2.version>


### PR DESCRIPTION
This PR adds support for reading/writing against tables that use the new [On-Demand Billing Mode](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ReadWriteCapacityMode.html#HowItWorks.OnDemand).  For tables that have this mode enabled the read/write throughput will always be zero causing the connector to never do any reading or writing.  When this mode is enabled on a table, we want to allow one to configure the max read/write throughput to use to allow one to stay within their account throughput limits. 

```
[INFO] Reactor Summary for EMRDynamoDBConnector 4.8.0-SNAPSHOT:
[INFO] 
[INFO] EMRDynamoDBConnector ............................... SUCCESS [  0.345 s]
[INFO] EMRDynamoDBHadoop .................................. SUCCESS [02:27 min]
[INFO] EMRDynamoDBConnectorShims .......................... SUCCESS [  0.003 s]
[INFO] ShimsCommon ........................................ SUCCESS [  0.330 s]
[INFO] Hive1Shims ......................................... SUCCESS [  0.268 s]
[INFO] Hive2Shims ......................................... SUCCESS [  0.102 s]
[INFO] Hive1.2Shims ....................................... SUCCESS [  0.171 s]
[INFO] ShimsLoader ........................................ SUCCESS [  0.080 s]
[INFO] EMRDynamoDBHive .................................... SUCCESS [  1.688 s]
[INFO] EMRDynamoDBTools ................................... SUCCESS [  1.216 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  02:31 min
[INFO] Finished at: 2018-12-19T15:21:39Z
[INFO] ------------------------------------------------------------------------
```

The contributing guidelines suggest updating documentation, but I couldn't seem to find that in this repo.  If someone can point me to how to do that, I can update that as well. 