### PR TITLE
Fixing NullPointerException for provisioned mode tables

### DIFF
--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/read/ReadIopsCalculator.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/read/ReadIopsCalculator.java
@@ -65,7 +65,7 @@ public class ReadIopsCalculator implements IopsCalculator {
 
   private double getThroughput() {
     TableDescription tableDescription = dynamoDBClient.describeTable(tableName);
-    if (tableDescription.getBillingModeSummary() != null &&
+    if (tableDescription.getBillingModeSummary() == null ||
         tableDescription.getBillingModeSummary().getBillingMode()
             .equalsIgnoreCase(DynamoDBConstants.BILLING_MODE_PROVISIONED)) {
       ProvisionedThroughputDescription provisionedThroughput = tableDescription

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/write/WriteIopsCalculator.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/write/WriteIopsCalculator.java
@@ -84,7 +84,7 @@ public class WriteIopsCalculator implements IopsCalculator {
 
   private double getThroughput() {
     TableDescription tableDescription = dynamoDBClient.describeTable(tableName);
-    if (tableDescription.getBillingModeSummary() != null && tableDescription.getBillingModeSummary()
+    if (tableDescription.getBillingModeSummary() == null || tableDescription.getBillingModeSummary()
         .getBillingMode().equalsIgnoreCase(DynamoDBConstants.BILLING_MODE_PROVISIONED)) {
       ProvisionedThroughputDescription provisionedThroughput =
           tableDescription.getProvisionedThroughput();

--- a/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/DynamoDBSerDe.java
+++ b/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/DynamoDBSerDe.java
@@ -15,6 +15,7 @@ package org.apache.hadoop.hive.dynamodb;
 
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 
+import com.amazonaws.services.dynamodbv2.model.BillingModeSummary;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -207,8 +208,9 @@ public class DynamoDBSerDe extends AbstractSerDe {
       throw new RuntimeException("Could not get cluster capacity.", e);
     }
 
+    BillingModeSummary billingModeSummary = client.describeTable(dynamoDBTableName).getBillingModeSummary();
     if (maxMapTasks > writesPerSecond &&
-            client.describeTable(dynamoDBTableName).getBillingModeSummary().getBillingMode().equals(DynamoDBConstants.BILLING_MODE_PROVISIONED)) {
+            (billingModeSummary == null || billingModeSummary.getBillingMode().equals(DynamoDBConstants.BILLING_MODE_PROVISIONED))) {
       String message = "WARNING: Configured write throughput of the dynamodb table "
           + dynamoDBTableName + " is less than the cluster map capacity." + " ClusterMapCapacity: "
           + maxMapTasks + " WriteThroughput: " + writesPerSecond + "\nWARNING: Writes to this "

--- a/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/DynamoDBStorageHandler.java
+++ b/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/DynamoDBStorageHandler.java
@@ -168,7 +168,8 @@ public class DynamoDBStorageHandler
             .getProperty(DynamoDBConstants.THROUGHPUT_WRITE_PERCENT));
       }
 
-      if (description.getBillingModeSummary().getBillingMode()
+      if (description.getBillingModeSummary() == null
+          || description.getBillingModeSummary().getBillingMode()
           .equals(DynamoDBConstants.BILLING_MODE_PROVISIONED)) {
         jobProperties.put(DynamoDBConstants.READ_THROUGHPUT,
             description.getProvisionedThroughput().getReadCapacityUnits().toString());

--- a/emr-dynamodb-tools/src/main/java/org/apache/hadoop/dynamodb/tools/DynamoDBExport.java
+++ b/emr-dynamodb-tools/src/main/java/org/apache/hadoop/dynamodb/tools/DynamoDBExport.java
@@ -112,7 +112,8 @@ public class DynamoDBExport extends Configured implements Tool {
     Long tableSizeBytes = description.getTableSizeBytes();
     Double averageItemSize = DynamoDBUtil.calculateAverageItemSize(description);
 
-    if (description.getBillingModeSummary().getBillingMode()
+    if (description.getBillingModeSummary() == null
+            || description.getBillingModeSummary().getBillingMode()
         .equals(DynamoDBConstants.BILLING_MODE_PROVISIONED)) {
       jobConf.set(DynamoDBConstants.READ_THROUGHPUT,
           description.getProvisionedThroughput().getReadCapacityUnits().toString());

--- a/emr-dynamodb-tools/src/main/java/org/apache/hadoop/dynamodb/tools/DynamoDBImport.java
+++ b/emr-dynamodb-tools/src/main/java/org/apache/hadoop/dynamodb/tools/DynamoDBImport.java
@@ -95,7 +95,8 @@ public class DynamoDBImport extends Configured implements Tool {
     DynamoDBClient client = new DynamoDBClient(jobConf);
     TableDescription description = client.describeTable(tableName);
 
-    if (description.getBillingModeSummary().getBillingMode()
+    if (description.getBillingModeSummary() == null
+        || description.getBillingModeSummary().getBillingMode()
         .equals(DynamoDBConstants.BILLING_MODE_PROVISIONED)) {
       jobConf.set(DynamoDBConstants.READ_THROUGHPUT,
           description.getProvisionedThroughput().getReadCapacityUnits().toString());


### PR DESCRIPTION
- billingModeSummary can be null on new provisioned mode tables

Bug was introduced in this PR https://github.com/awslabs/emr-dynamodb-connector/commit/dca6c7547c446e33aff25da7fdf7d15c10aef516 (if you look at that PR you'll see a similar null check in other places)