### PR TITLE
Correct Item size by adding support for Map, List Types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ target
 **/*.iml
 *.swp
 *.DS_Store
+.classpath
+.project
+.settings/

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBUtil.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBUtil.java
@@ -186,6 +186,14 @@ public final class DynamoDBUtil {
       for (ByteBuffer byteBuffer : att.getBS()) {
         byteSize += byteBuffer.array().length;
       }
+    } else if (att.getM() != null) {
+      for (Entry<String, AttributeValue> entry : att.getM().entrySet()) {
+    	byteSize += getAttributeSizeBytes(entry.getValue()) + entry.getKey().getBytes(CHARACTER_ENCODING).length;
+      }
+    } else if (att.getL() != null) {
+      for (AttributeValue entry : att.getL()) {
+        byteSize += getAttributeSizeBytes(entry);
+      }
     }
     return byteSize;
   }

--- a/emr-dynamodb-hadoop/src/test/java/org/apache/hadoop/dynamodb/DynamoDBUtilTest.java
+++ b/emr-dynamodb-hadoop/src/test/java/org/apache/hadoop/dynamodb/DynamoDBUtilTest.java
@@ -39,6 +39,7 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.UnsupportedEncodingException;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -71,6 +72,34 @@ public class DynamoDBUtilTest {
     item.put("numberArray", new AttributeValue().withNS(numberArray));
 
     assertEquals(131, DynamoDBUtil.getItemSizeBytes(item));
+  }
+  
+  @Test
+  public void testListItemSize() throws UnsupportedEncodingException {
+    Map<String, AttributeValue> item = new HashMap<>();
+    item.put("id", new AttributeValue("AfFLIHsycSvZoEhPPKHUrtwewDAlcD"));
+    item.put("payload", new AttributeValue("AfFLIHsycSvZoEhPPKHUrtwewDAlcD"));
+    item.put("number", new AttributeValue().withN("3592.0001"));
+    List<AttributeValue> attrList = new ArrayList<>();
+    attrList.add(new AttributeValue().withN("20123"));
+    attrList.add(new AttributeValue("QERASdfklkajsdfasdf"));
+    item.put("testList", new AttributeValue().withL(attrList));
+
+    assertEquals(116, DynamoDBUtil.getItemSizeBytes(item));
+  }
+  
+  @Test
+  public void testMapItemSize() throws UnsupportedEncodingException {
+    Map<String, AttributeValue> item = new HashMap<>();
+    item.put("id", new AttributeValue("AfFLIHsycSvZoEhPPKHUrtwewDAlcD"));
+    item.put("payload", new AttributeValue("AfFLIHsycSvZoEhPPKHUrtwewDAlcD"));
+    item.put("number", new AttributeValue().withN("3592.0001"));
+    Map<String, AttributeValue> attrMap = new HashMap<>();
+    attrMap.put("mapNumber", new AttributeValue().withN("20123"));
+    attrMap.put("mapString", new AttributeValue("QERASdfklkajsdfasdf"));
+    item.put("testMap", new AttributeValue().withM(attrMap));
+
+    assertEquals(133, DynamoDBUtil.getItemSizeBytes(item));
   }
 
   @Test


### PR DESCRIPTION
Added logic for including the sizes of Map and List Attribute types in the calculation for total size of the Dynamo Item. Without including these types the calculated size of the Dynamo Item is incorrect and the RuntimeException that should be thrown if an item exceeds 400KB (called by DynamoDBClient:putBatch()) is not ever thrown.

This pull request is not directly related to any issue. Just thought it would be helpful for others who use Maps and Lists in Dynamo Items
