### PR TITLE
Auto scale in provisioned billing mode if user hasn't explicitly specify throughput

### DIFF
--- a/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/DynamoDBStorageHandler.java
+++ b/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/DynamoDBStorageHandler.java
@@ -171,10 +171,7 @@ public class DynamoDBStorageHandler
       if (description.getBillingModeSummary() == null
           || description.getBillingModeSummary().getBillingMode()
           .equals(DynamoDBConstants.BILLING_MODE_PROVISIONED)) {
-        jobProperties.put(DynamoDBConstants.READ_THROUGHPUT,
-            description.getProvisionedThroughput().getReadCapacityUnits().toString());
-        jobProperties.put(DynamoDBConstants.WRITE_THROUGHPUT,
-            description.getProvisionedThroughput().getWriteCapacityUnits().toString());
+        useExplicitThroughputIfRequired(jobProperties, tableDesc);
       } else {
         // If not specified at the table level, set default value
         jobProperties.put(DynamoDBConstants.READ_THROUGHPUT, tableDesc.getProperties()
@@ -198,6 +195,18 @@ public class DynamoDBStorageHandler
 
     } finally {
       client.close();
+    }
+  }
+
+  private void useExplicitThroughputIfRequired(Map<String, String> jobProperties, TableDesc tableDesc) {
+    String userRequiredReadThroughput = tableDesc.getProperties().getProperty(DynamoDBConstants.READ_THROUGHPUT);
+    if (userRequiredReadThroughput != null) {
+      jobProperties.put(DynamoDBConstants.READ_THROUGHPUT, userRequiredReadThroughput);
+    }
+
+    String userRequiredWriteThroughput = tableDesc.getProperties().getProperty(DynamoDBConstants.WRITE_THROUGHPUT);
+    if (userRequiredWriteThroughput != null) {
+      jobProperties.put(DynamoDBConstants.WRITE_THROUGHPUT, userRequiredWriteThroughput);
     }
   }
 


### PR DESCRIPTION
Auto scale in provisioned billing mode if user hasn't explicitly specify throughput.

*Issue : https://github.com/awslabs/emr-dynamodb-connector/issues/99*

*Description of changes:*
Auto scaling in provisioned mode was working in previous version, but has been suppressed in [commit](https://github.com/awslabs/emr-dynamodb-connector/commit/dca6c7547c446e33aff25da7fdf7d15c10aef516#diff-9ac2a3ee2c139328fd4a0076417da17aL70). 

This commit is trying to resolve this issue by do not set READ/WRITE_THROUGHPUT if user did not explicitly set it in table description. Then IopsCalculator will get latest provisioned capacity periodically. 

It'll respect user's explicit set READ/WRITE_THROUGHPUT if there's any.

It keeps current behavior if table's billing mode is ON_DEMAND. 

Related changes are: 
* When initial start in [DynamoDBStorageHandler](https://github.com/awslabs/emr-dynamodb-connector/blob/master/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/DynamoDBStorageHandler.java#L171), jobConfig set READ/WRITE_THROUGHPUT 
*  Then in [IopsCalculator](https://github.com/awslabs/emr-dynamodb-connector/blob/master/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/write/WriteIopsCalculator.java#L68) it takes precedence over latest dynamodb capacity.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
Fixes #99 