### PR TITLE
Added support for using STS session credentials

### DIFF
--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/CredentialPairName.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/CredentialPairName.java
@@ -17,10 +17,18 @@ public final class CredentialPairName {
 
   private final String accessKeyName;
   private final String secretKeyName;
+  private final String sessionkeyName;
 
   public CredentialPairName(String accessKeyName, String secretKeyName) {
     this.accessKeyName = accessKeyName;
     this.secretKeyName = secretKeyName;
+    this.sessionkeyName = null;
+  }
+
+  public CredentialPairName(String accessKeyName, String secretKeyName, String sessionkeyName) {
+    this.accessKeyName = accessKeyName;
+    this.secretKeyName = secretKeyName;
+    this.sessionkeyName = sessionkeyName;
   }
 
   public String getAccessKeyName() {
@@ -29,5 +37,9 @@ public final class CredentialPairName {
 
   public String getSecretKeyName() {
     return secretKeyName;
+  }
+
+  public String getSessionKeyName() {
+    return sessionkeyName;
   }
 }

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBConstants.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBConstants.java
@@ -26,6 +26,7 @@ public interface DynamoDBConstants {
   // Credentials
   String DYNAMODB_ACCESS_KEY_CONF = "dynamodb.awsAccessKeyId";
   String DYNAMODB_SECRET_KEY_CONF = "dynamodb.awsSecretAccessKey";
+  String DYNAMODB_SESSION_TOKEN_CONF = "dynamodb.awsSessionToken";
   String DEFAULT_ACCESS_KEY_CONF = "fs.s3.awsAccessKeyId";
   String DEFAULT_SECRET_KEY_CONF = "fs.s3.awsSecretAccessKey";
   String CUSTOM_CREDENTIALS_PROVIDER_CONF = "dynamodb.customAWSCredentialsProvider";

--- a/emr-dynamodb-hadoop/src/test/java/org/apache/hadoop/dynamodb/DynamoDBClientTest.java
+++ b/emr-dynamodb-hadoop/src/test/java/org/apache/hadoop/dynamodb/DynamoDBClientTest.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableMap;
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.AWSSessionCredentials;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 
@@ -120,6 +121,25 @@ public class DynamoDBClientTest {
     DynamoDBClient dynamoDBClient = new DynamoDBClient();
     expectedException.expect(ClassCastException.class);
     dynamoDBClient.getAWSCredentialsProvider(conf);
+  }
+
+  @Test
+  public void testBasicSessionCredentials(){
+    final String DYNAMODB_ACCESS_KEY = "abc";
+    final String DYNAMODB_SECRET_KEY = "xyz";
+    final String DYNAMODB_SESSION_KEY = "007";
+    Configuration conf = new Configuration();
+    conf.set(DynamoDBConstants.DYNAMODB_ACCESS_KEY_CONF, DYNAMODB_ACCESS_KEY);
+    conf.set(DynamoDBConstants.DYNAMODB_SECRET_KEY_CONF, DYNAMODB_SECRET_KEY);
+    conf.set(DynamoDBConstants.DYNAMODB_SESSION_TOKEN_CONF, DYNAMODB_SESSION_KEY);
+
+    DynamoDBClient dynamoDBClient = new DynamoDBClient();
+    AWSCredentialsProvider provider = dynamoDBClient.getAWSCredentialsProvider(conf);
+    AWSSessionCredentials sessionCredentials = (AWSSessionCredentials) provider.getCredentials();
+    Assert.assertEquals(DYNAMODB_ACCESS_KEY, sessionCredentials.getAWSAccessKeyId());
+    Assert.assertEquals(DYNAMODB_SECRET_KEY, sessionCredentials.getAWSSecretKey());
+    Assert.assertEquals(DYNAMODB_SESSION_KEY, sessionCredentials.getSessionToken());
+
   }
 
   @Test


### PR DESCRIPTION
*Issue #, if available:*
#75 

*Description of changes:*
 To support cross-account DynamoDB access using STS  instead of using static access keys.

 Added new property **dynamodb.awsSessionToken** to pass the session key

 *Sample invocation :*
` 
hadoop jar target/emr-dynamodb-tools-4.10.0-SNAPSHOT.jar org.apache.hadoop.dynamodb.tools.DynamoDBExport -Ddynamodb.awsSessionToken=${SESSION_TOKEN} -Ddynamodb.awsAccessKeyId=${ACCESS_KEY_ID} -Ddynamodb.awsSecretAccessKey=${SECRET_ACCESS_KEY}
 /where/output/should/go my-dynamo-table-name
`

Attached Tests Results:
[sts_tests.log](https://github.com/awslabs/emr-dynamodb-connector/files/3281139/sts_tests.log)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
