### PR TITLE
Fix exception thrown for bad mapping

### DIFF
--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBUtil.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBUtil.java
@@ -145,8 +145,8 @@ public final class DynamoDBUtil {
     try {
       int itemSize = 0;
       for (Entry<String, AttributeValue> entry : item.entrySet()) {
-        itemSize += entry.getKey().getBytes(CHARACTER_ENCODING).length;
-        itemSize += getAttributeSizeBytes(entry.getValue());
+        itemSize += entry.getKey() != null ? entry.getKey().getBytes(CHARACTER_ENCODING).length : 0;
+        itemSize += entry.getValue() != null ? getAttributeSizeBytes(entry.getValue()) : 0;
       }
       return itemSize;
     } catch (UnsupportedEncodingException e) {

--- a/emr-dynamodb-hive/src/test/java/org/apache/hadoop/hive/dynamodb/DynamoDBStorageHandlerTest.java
+++ b/emr-dynamodb-hive/src/test/java/org/apache/hadoop/hive/dynamodb/DynamoDBStorageHandlerTest.java
@@ -52,19 +52,42 @@ public class DynamoDBStorageHandlerTest {
 
     Table table = new Table();
     Map<String, String> parameters = Maps.newHashMap();
-    parameters.put(DynamoDBConstants.DYNAMODB_COLUMN_MAPPING, "col1:dynamo_col1$,hashKey:hashKey");
+    parameters.put(DynamoDBConstants.DYNAMODB_COLUMN_MAPPING, "col1:dynamo_col1$,hashMap:hashMap");
     table.setParameters(parameters);
     StorageDescriptor sd = new StorageDescriptor();
     List<FieldSchema> cols = Lists.newArrayList();
     cols.add(new FieldSchema("col1", "string", ""));
     cols.add(new FieldSchema("col2", "tinyint", ""));
-    cols.add(new FieldSchema("col3", "map<string,string>", ""));
-    cols.add(new FieldSchema("hashMap", "string", ""));
+    cols.add(new FieldSchema("col3", "string", ""));
+    cols.add(new FieldSchema("hashMap", "map<string,string>", ""));
     sd.setCols(cols);
     table.setSd(sd);
 
     exceptionRule.expect(MetaException.class);
     exceptionRule.expectMessage("Could not find column mapping for column: col2");
+    storageHandler.checkTableSchemaMapping(description, table);
+  }
+
+  @Test
+  public void testCheckTableSchemaMappingMissingColumnMapping() throws MetaException {
+    TableDescription description = getHashRangeTable();
+
+    Table table = new Table();
+    Map<String, String> parameters = Maps.newHashMap();
+    parameters.put(DynamoDBConstants.DYNAMODB_COLUMN_MAPPING, "col1:dynamo_col1$," +
+	    "col2:dynamo_col2#,hashKey:hashKey,hashMap:hashMap");
+    table.setParameters(parameters);
+    StorageDescriptor sd = new StorageDescriptor();
+    List<FieldSchema> cols = Lists.newArrayList();
+    cols.add(new FieldSchema("col1", "string", ""));
+    cols.add(new FieldSchema("hashMap", "map<string,string>", ""));
+    sd.setCols(cols);
+    table.setSd(sd);
+
+    exceptionRule.expect(MetaException.class);
+    exceptionRule.expectMessage("Could not find column(s) for column mapping(s): ");
+    exceptionRule.expectMessage("col2:dynamo_col2#");
+    exceptionRule.expectMessage("hashkey:hashKey");
     storageHandler.checkTableSchemaMapping(description, table);
   }
 


### PR DESCRIPTION
1. Throw an exception if the mapping between Hive schema columns and
keys in dynamodb.column.mapping is not 1:1.
2. Allow for null (0-byte) DynamoDB items.

Issue #74


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
