### PR TITLE
Fix parsing logic for List type

### DIFF
--- a/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/DerivedHiveTypeConstants.java
+++ b/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/DerivedHiveTypeConstants.java
@@ -13,43 +13,36 @@
 
 package org.apache.hadoop.hive.dynamodb;
 
-import org.apache.hadoop.hive.serde.Constants;
+import org.apache.commons.lang.StringUtils;
+import org.apache.hadoop.hive.serde.serdeConstants;
+
+import java.util.Arrays;
+import java.util.List;
 
 public class DerivedHiveTypeConstants {
 
-  public static final String BIGINT_ARRAY_TYPE_NAME = Constants.LIST_TYPE_NAME + "<" + Constants
-      .BIGINT_TYPE_NAME + ">";
+  private static final List<Character> COLLECTION_TYPE_DELIMITERS = Arrays.asList('<', '>');
+  private static final char MAP_KEY_VALUE_TYPE_DELIMITER = ',';
 
-  public static final String DOUBLE_ARRAY_TYPE_NAME = Constants.LIST_TYPE_NAME + "<" + Constants
-      .DOUBLE_TYPE_NAME + ">";
-
-  public static final String STRING_ARRAY_TYPE_NAME = Constants.LIST_TYPE_NAME + "<" + Constants
-      .STRING_TYPE_NAME + ">";
-
-  public static final String BINARY_ARRAY_TYPE_NAME = Constants.LIST_TYPE_NAME + "<" + Constants
-      .BINARY_TYPE_NAME + ">";
+  public static final String BIGINT_ARRAY_TYPE_NAME = setArrayElementType(serdeConstants.BIGINT_TYPE_NAME);
+  public static final String DOUBLE_ARRAY_TYPE_NAME = setArrayElementType(serdeConstants.DOUBLE_TYPE_NAME);
+  public static final String STRING_ARRAY_TYPE_NAME = setArrayElementType(serdeConstants.STRING_TYPE_NAME);
+  public static final String BINARY_ARRAY_TYPE_NAME = setArrayElementType(serdeConstants.BINARY_TYPE_NAME);
 
   /* A map<string, string> map. */
-  public static final String ITEM_MAP_TYPE_NAME = Constants.MAP_TYPE_NAME + "<" + Constants
-      .STRING_TYPE_NAME + "," + Constants.STRING_TYPE_NAME + ">";
+  public static final String ITEM_MAP_TYPE_NAME = setMapKeyValueTypes(serdeConstants.STRING_TYPE_NAME,
+          serdeConstants.STRING_TYPE_NAME);
 
-  public static final String STRING_BIGINT_MAP_TYPE_NAME = Constants.MAP_TYPE_NAME + "<" + Constants.STRING_TYPE_NAME
-    + "," + Constants.BIGINT_TYPE_NAME + ">";
-  public static final String STRING_DOUBLE_MAP_TYPE_NAME = Constants.MAP_TYPE_NAME + "<" + Constants.STRING_TYPE_NAME
-    + "," + Constants.DOUBLE_TYPE_NAME + ">";
+  private static String setArrayElementType(String elementType) {
+    return serdeConstants.LIST_TYPE_NAME + StringUtils.join(COLLECTION_TYPE_DELIMITERS, elementType);
+  }
 
-  public static final String BIGINT_ARRAY_LIST_TYPE_NAME = Constants.LIST_TYPE_NAME + "<" + Constants
-    .BIGINT_TYPE_NAME + ">";
-  public static final String DOUBLE_ARRAY_LIST_TYPE_NAME = Constants.LIST_TYPE_NAME + "<" + Constants
-    .DOUBLE_TYPE_NAME + ">";
-  public static final String STRING_ARRAY_LIST_TYPE_NAME = Constants.LIST_TYPE_NAME + "<" + Constants
-    .STRING_TYPE_NAME + ">";
+  private static String setMapKeyValueTypes(String... types) {
+    return serdeConstants.MAP_TYPE_NAME + StringUtils.join(COLLECTION_TYPE_DELIMITERS,
+            StringUtils.join(types, MAP_KEY_VALUE_TYPE_DELIMITER));
+  }
 
-
-  public static final String LIST_ITEM_MAP_TYPE_NAME = Constants.LIST_TYPE_NAME + "<" +
-    ITEM_MAP_TYPE_NAME + ">";
-  public static final String LIST_STRING_BIG_INT_MAP_TYPE_NAME = Constants.LIST_TYPE_NAME + "<" +
-    STRING_BIGINT_MAP_TYPE_NAME + ">";
-  public static final String LIST_STRING_BIG_DOUBLE_MAP_TYPE_NAME = Constants.LIST_TYPE_NAME + "<" +
-    STRING_DOUBLE_MAP_TYPE_NAME + ">";
+  public static String getArrayElementType(String hiveType) {
+    return hiveType.substring(hiveType.indexOf(COLLECTION_TYPE_DELIMITERS.get(0)) + 1, hiveType.length() - 1);
+  }
 }

--- a/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/DynamoDBExportSerDe.java
+++ b/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/DynamoDBExportSerDe.java
@@ -42,7 +42,7 @@ import java.util.Map;
 import java.util.Properties;
 
 /**
- * This class is used to read the DynanmoDB backup format and allow querying individual columns from
+ * This class is used to read the DynamoDB backup format and allow querying individual columns from
  * the schemaless backup.
  */
 public class DynamoDBExportSerDe extends AbstractSerDe {

--- a/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/DynamoDBListObjectInspector.java
+++ b/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/DynamoDBListObjectInspector.java
@@ -1,0 +1,21 @@
+package org.apache.hadoop.hive.dynamodb;
+
+import org.apache.hadoop.hive.dynamodb.type.HiveDynamoDBListTypeFactory;
+import org.apache.hadoop.hive.dynamodb.type.HiveDynamoDBType;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
+
+import java.util.List;
+import java.util.Map;
+
+public class DynamoDBListObjectInspector extends DynamoDBObjectInspector {
+
+  public DynamoDBListObjectInspector(List<String> columnNames, List<TypeInfo> columnTypes,
+                                     Map<String, String> columnMappings) {
+    super(columnNames, columnTypes, columnMappings);
+  }
+
+  @Override
+  protected HiveDynamoDBType getTypeObjectFromHiveType(String type) {
+    return HiveDynamoDBListTypeFactory.getTypeObjectFromHiveType(type);
+  }
+}

--- a/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/DynamoDBListSerDe.java
+++ b/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/DynamoDBListSerDe.java
@@ -1,11 +1,15 @@
 package org.apache.hadoop.hive.dynamodb;
 
-import org.apache.hadoop.hive.dynamodb.type.HiveDynamoDBListTypeFactory;
-import org.apache.hadoop.hive.dynamodb.type.HiveDynamoDBType;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
+
+import java.util.List;
+import java.util.Map;
 
 public class DynamoDBListSerDe extends DynamoDBSerDe {
+
   @Override
-  protected HiveDynamoDBType getTypeObjectFromHiveType(String type) {
-    return HiveDynamoDBListTypeFactory.getTypeObjectFromHiveType(type);
+  protected DynamoDBObjectInspector newObjectInspector(List<String> columnNames, List<TypeInfo> columnTypes,
+                                                       Map<String,String> columnMappings) {
+    return new DynamoDBListObjectInspector(columnNames, columnTypes, columnMappings);
   }
 }

--- a/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/type/HiveDynamoDBBinarySetType.java
+++ b/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/type/HiveDynamoDBBinarySetType.java
@@ -14,7 +14,6 @@
 package org.apache.hadoop.hive.dynamodb.type;
 
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
-
 import org.apache.hadoop.dynamodb.type.DynamoDBBinarySetType;
 import org.apache.hadoop.hive.dynamodb.util.DynamoDBDataParser;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
@@ -26,31 +25,21 @@ import java.util.List;
 
 public class HiveDynamoDBBinarySetType extends DynamoDBBinarySetType implements HiveDynamoDBType {
 
-  private final DynamoDBDataParser parser = new DynamoDBDataParser();
-
   @Override
   public AttributeValue getDynamoDBData(Object data, ObjectInspector objectInspector) {
-    List<ByteBuffer> values = parser.getByteBuffers(data, objectInspector, getDynamoDBType());
-    if ((values != null) && (!values.isEmpty())) {
-      return new AttributeValue().withBS(values);
-    } else {
-      return null;
-    }
+    List<ByteBuffer> values = DynamoDBDataParser.getByteBuffers(data, objectInspector, getDynamoDBType());
+    return (values == null || values.isEmpty()) ? null : new AttributeValue().withBS(values);
   }
 
   @Override
   public Object getHiveData(AttributeValue data, String hiveType) {
-    if (data == null) {
-      return null;
-    }
-
     List<ByteBuffer> byteBuffers = data.getBS();
 
     if (byteBuffers == null || byteBuffers.isEmpty()) {
       return null;
     }
 
-    List<byte[]> byteArrays = new ArrayList<byte[]>(byteBuffers.size());
+    List<byte[]> byteArrays = new ArrayList<>(byteBuffers.size());
     for (ByteBuffer byteBuffer : byteBuffers) {
       byteArrays.add(Arrays.copyOf(byteBuffer.array(), byteBuffer.array().length));
     }

--- a/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/type/HiveDynamoDBBinaryType.java
+++ b/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/type/HiveDynamoDBBinaryType.java
@@ -14,7 +14,6 @@
 package org.apache.hadoop.hive.dynamodb.type;
 
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
-
 import org.apache.hadoop.dynamodb.type.DynamoDBBinaryType;
 import org.apache.hadoop.hive.dynamodb.util.DynamoDBDataParser;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
@@ -23,24 +22,14 @@ import java.nio.ByteBuffer;
 
 public class HiveDynamoDBBinaryType extends DynamoDBBinaryType implements HiveDynamoDBType {
 
-  private final DynamoDBDataParser parser = new DynamoDBDataParser();
-
   @Override
   public AttributeValue getDynamoDBData(Object data, ObjectInspector objectInspector) {
-    ByteBuffer value = parser.getByteBuffer(data, objectInspector);
+    ByteBuffer value = DynamoDBDataParser.getByteBuffer(data, objectInspector);
     return new AttributeValue().withB(value);
   }
 
   @Override
   public Object getHiveData(AttributeValue data, String hiveType) {
-    if (data == null) {
-      return null;
-    }
-
-    if (data.getB() == null) {
-      return null;
-    }
-
-    return data.getB().array();
+    return data.getB() == null ? null : data.getB().array();
   }
 }

--- a/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/type/HiveDynamoDBBooleanType.java
+++ b/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/type/HiveDynamoDBBooleanType.java
@@ -1,27 +1,20 @@
 package org.apache.hadoop.hive.dynamodb.type;
 
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
-
 import org.apache.hadoop.dynamodb.type.DynamoDBBooleanType;
 import org.apache.hadoop.hive.dynamodb.util.DynamoDBDataParser;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 
-
 public class HiveDynamoDBBooleanType extends DynamoDBBooleanType implements HiveDynamoDBType {
 
-    private final DynamoDBDataParser parser = new DynamoDBDataParser();
+  @Override
+  public AttributeValue getDynamoDBData(Object data, ObjectInspector objectInspector) {
+    Boolean value = DynamoDBDataParser.getBoolean(data, objectInspector);
+    return value == null ? null : new AttributeValue().withBOOL(value);
+  }
 
-    @Override
-    public AttributeValue getDynamoDBData(Object data, ObjectInspector objectInspector) {
-        Boolean value = parser.getBoolean(data, objectInspector);
-        return new AttributeValue().withBOOL(value);
-    }
-
-    @Override
-    public Object getHiveData(AttributeValue data, String hiveType) {
-        if (data == null) {
-            return null;
-        }
-        return data.getBOOL();
-    }
+  @Override
+  public Object getHiveData(AttributeValue data, String hiveType) {
+    return data.getBOOL();
+  }
 }

--- a/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/type/HiveDynamoDBListTypeFactory.java
+++ b/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/type/HiveDynamoDBListTypeFactory.java
@@ -12,35 +12,17 @@
 
 package org.apache.hadoop.hive.dynamodb.type;
 
-import org.apache.hadoop.hive.dynamodb.DerivedHiveTypeConstants;
-
-import java.util.HashMap;
-import java.util.Map;
+import org.apache.commons.lang.StringUtils;
+import org.apache.hadoop.hive.serde.serdeConstants;
 
 public class HiveDynamoDBListTypeFactory extends HiveDynamoDBTypeFactory {
 
-  private static final HiveDynamoDBType NUMBER_LIST_TYPE = new HiveDynamoDBListType();
-  private static final HiveDynamoDBType STRING_LIST_TYPE = new HiveDynamoDBListType();
-  private static final HiveDynamoDBType LIST_ITEM_TYPE = new HiveDynamoDBListType();
-  private static final HiveDynamoDBType MAP_TYPE = new HiveDynamoDBMapType();
-
-  private static final Map<String, HiveDynamoDBType> HIVE_TYPE_MAP = new HashMap<>();
-  static {
-    HIVE_TYPE_MAP.put(DerivedHiveTypeConstants.BIGINT_ARRAY_LIST_TYPE_NAME, NUMBER_LIST_TYPE);
-    HIVE_TYPE_MAP.put(DerivedHiveTypeConstants.DOUBLE_ARRAY_LIST_TYPE_NAME, NUMBER_LIST_TYPE);
-    HIVE_TYPE_MAP.put(DerivedHiveTypeConstants.STRING_ARRAY_LIST_TYPE_NAME, STRING_LIST_TYPE);
-    HIVE_TYPE_MAP.put(DerivedHiveTypeConstants.STRING_BIGINT_MAP_TYPE_NAME, MAP_TYPE);
-    HIVE_TYPE_MAP.put(DerivedHiveTypeConstants.LIST_STRING_BIG_INT_MAP_TYPE_NAME, LIST_ITEM_TYPE);
-    HIVE_TYPE_MAP.put(DerivedHiveTypeConstants.LIST_STRING_BIG_DOUBLE_MAP_TYPE_NAME, LIST_ITEM_TYPE);
-    HIVE_TYPE_MAP.put(DerivedHiveTypeConstants.LIST_ITEM_MAP_TYPE_NAME, LIST_ITEM_TYPE);
-  }
+  private static final HiveDynamoDBType LIST_TYPE = new HiveDynamoDBListType();
 
   public static HiveDynamoDBType getTypeObjectFromHiveType(String hiveType) {
-    HiveDynamoDBType aType = HIVE_TYPE_MAP.get(hiveType.toLowerCase());
-    if (aType != null) {
-      return aType;
+    if (StringUtils.startsWithIgnoreCase(hiveType, serdeConstants.LIST_TYPE_NAME)) {
+      return LIST_TYPE;
     }
-    return HiveDynamoDBTypeFactory
-      .getTypeObjectFromHiveType(hiveType.toLowerCase());
+    return HiveDynamoDBTypeFactory.getTypeObjectFromHiveType(hiveType.toLowerCase());
   }
 }

--- a/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/type/HiveDynamoDBMapType.java
+++ b/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/type/HiveDynamoDBMapType.java
@@ -19,11 +19,9 @@ import static org.apache.hadoop.hive.dynamodb.type.HiveDynamoDBTypeUtil.parseMap
 
 public class HiveDynamoDBMapType  extends HiveDynamoDBItemType {
 
-  private final DynamoDBDataParser parser = new DynamoDBDataParser();
-
   @Override
   public AttributeValue getDynamoDBData(Object data, ObjectInspector objectInspector) {
-    return parseMap(parser.getMap(data, objectInspector));
+    return parseMap(DynamoDBDataParser.getMap(data, objectInspector));
   }
 
   @Override

--- a/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/type/HiveDynamoDBNumberSetType.java
+++ b/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/type/HiveDynamoDBNumberSetType.java
@@ -14,7 +14,6 @@
 package org.apache.hadoop.hive.dynamodb.type;
 
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
-
 import org.apache.hadoop.dynamodb.type.DynamoDBNumberSetType;
 import org.apache.hadoop.hive.dynamodb.util.DynamoDBDataParser;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
@@ -23,24 +22,15 @@ import java.util.List;
 
 public class HiveDynamoDBNumberSetType extends DynamoDBNumberSetType implements HiveDynamoDBType {
 
-  private final DynamoDBDataParser parser = new DynamoDBDataParser();
-
   @Override
   public AttributeValue getDynamoDBData(Object data, ObjectInspector objectInspector) {
-    List<String> values = parser.getSetAttribute(data, objectInspector, getDynamoDBType());
-    if ((values != null) && (!values.isEmpty())) {
-      return new AttributeValue().withNS(values);
-    } else {
-      return null;
-    }
+    List<String> values = DynamoDBDataParser.getSetAttribute(data, objectInspector, getDynamoDBType());
+    return (values == null || values.isEmpty()) ? null : new AttributeValue().withNS(values);
   }
 
   @Override
   public Object getHiveData(AttributeValue data, String hiveType) {
-    if (data == null) {
-      return null;
-    }
-    return parser.getNumberObjectList(data.getNS(), hiveType);
+    return DynamoDBDataParser.getNumberObjectList(data.getNS(), hiveType);
   }
 
 }

--- a/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/type/HiveDynamoDBNumberType.java
+++ b/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/type/HiveDynamoDBNumberType.java
@@ -14,26 +14,21 @@
 package org.apache.hadoop.hive.dynamodb.type;
 
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
-
 import org.apache.hadoop.dynamodb.type.DynamoDBNumberType;
 import org.apache.hadoop.hive.dynamodb.util.DynamoDBDataParser;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 
 public class HiveDynamoDBNumberType extends DynamoDBNumberType implements HiveDynamoDBType {
-  private final DynamoDBDataParser parser = new DynamoDBDataParser();
 
   @Override
   public AttributeValue getDynamoDBData(Object data, ObjectInspector objectInspector) {
-    String value = parser.getNumber(data, objectInspector);
-    return new AttributeValue().withN(value);
+    String value = DynamoDBDataParser.getNumber(data, objectInspector);
+    return value == null ? null : new AttributeValue().withN(value);
   }
 
   @Override
   public Object getHiveData(AttributeValue data, String hiveType) {
-    if (data == null) {
-      return null;
-    }
-    return parser.getNumberObject(data.getN(), hiveType);
+    return DynamoDBDataParser.getNumberObject(data.getN(), hiveType);
   }
 
 }

--- a/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/type/HiveDynamoDBStringSetType.java
+++ b/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/type/HiveDynamoDBStringSetType.java
@@ -14,7 +14,6 @@
 package org.apache.hadoop.hive.dynamodb.type;
 
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
-
 import org.apache.hadoop.dynamodb.type.DynamoDBStringSetType;
 import org.apache.hadoop.hive.dynamodb.util.DynamoDBDataParser;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
@@ -23,23 +22,14 @@ import java.util.List;
 
 public class HiveDynamoDBStringSetType extends DynamoDBStringSetType implements HiveDynamoDBType {
 
-  private final DynamoDBDataParser parser = new DynamoDBDataParser();
-
   @Override
   public AttributeValue getDynamoDBData(Object data, ObjectInspector objectInspector) {
-    List<String> values = parser.getSetAttribute(data, objectInspector, getDynamoDBType());
-    if ((values != null) && (!values.isEmpty())) {
-      return new AttributeValue().withSS(values);
-    } else {
-      return null;
-    }
+    List<String> values = DynamoDBDataParser.getSetAttribute(data, objectInspector, getDynamoDBType());
+    return (values == null || values.isEmpty()) ? null : new AttributeValue().withSS(values);
   }
 
   @Override
   public Object getHiveData(AttributeValue data, String hiveType) {
-    if (data == null) {
-      return null;
-    }
     return data.getSS();
   }
 

--- a/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/type/HiveDynamoDBStringType.java
+++ b/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/type/HiveDynamoDBStringType.java
@@ -21,23 +21,14 @@ import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 
 public class HiveDynamoDBStringType extends DynamoDBStringType implements HiveDynamoDBType {
 
-  private final DynamoDBDataParser parser = new DynamoDBDataParser();
-
   @Override
   public AttributeValue getDynamoDBData(Object data, ObjectInspector objectInspector) {
-    String value = parser.getString(data, objectInspector);
-    if (value != null) {
-      return new AttributeValue(value);
-    } else {
-      return null;
-    }
+    String value = DynamoDBDataParser.getString(data, objectInspector);
+    return value == null ? null : new AttributeValue(value);
   }
 
   @Override
   public Object getHiveData(AttributeValue data, String hiveType) {
-    if (data == null) {
-      return null;
-    }
     return data.getS();
   }
 

--- a/emr-dynamodb-hive/src/test/java/org/apache/hadoop/hive/dynamodb/HiveDynamoDBTypeUtilTest.java
+++ b/emr-dynamodb-hive/src/test/java/org/apache/hadoop/hive/dynamodb/HiveDynamoDBTypeUtilTest.java
@@ -1,49 +1,162 @@
 package org.apache.hadoop.hive.dynamodb;
 
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import org.apache.hadoop.hive.dynamodb.type.HiveDynamoDBListTypeFactory;
+import org.apache.hadoop.hive.dynamodb.type.HiveDynamoDBType;
+import org.apache.hadoop.hive.dynamodb.type.HiveDynamoDBTypeFactory;
 import org.apache.hadoop.hive.dynamodb.type.HiveDynamoDBTypeUtil;
+import org.apache.hadoop.hive.serde.serdeConstants;
 import org.apache.hadoop.hive.serde2.lazy.ByteArrayRef;
 import org.apache.hadoop.hive.serde2.lazy.LazyDouble;
+import org.apache.hadoop.hive.serde2.lazy.LazyLong;
 import org.apache.hadoop.hive.serde2.lazy.LazyObject;
+import org.apache.hadoop.hive.serde2.lazy.LazyString;
+import org.apache.hadoop.hive.serde2.lazy.objectinspector.primitive.LazyPrimitiveObjectInspectorFactory;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory;
+import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
 import org.apache.hadoop.io.Text;
 import org.junit.Test;
 
+import com.google.common.collect.Lists;
+
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
-import static org.apache.hadoop.hive.serde2.lazy.objectinspector.primitive.LazyPrimitiveObjectInspectorFactory.LAZY_DOUBLE_OBJECT_INSPECTOR;
+import static org.apache.hadoop.hive.serde2.lazy.objectinspector.primitive.LazyPrimitiveObjectInspectorFactory
+        .LAZY_DOUBLE_OBJECT_INSPECTOR;
+import static org.apache.hadoop.hive.serde2.lazy.objectinspector.primitive.LazyPrimitiveObjectInspectorFactory
+        .LAZY_LONG_OBJECT_INSPECTOR;
 import static org.junit.Assert.assertEquals;
 
 public class HiveDynamoDBTypeUtilTest {
 
+  private static final ObjectInspector STRING_OBJECT_INSPECTOR = PrimitiveObjectInspectorFactory
+          .getPrimitiveJavaObjectInspector(PrimitiveObjectInspector.PrimitiveCategory.STRING);
+  private static final ObjectInspector DOUBLE_OBJECT_INSPECTOR = PrimitiveObjectInspectorFactory
+          .getPrimitiveJavaObjectInspector(PrimitiveObjectInspector.PrimitiveCategory.DOUBLE);
+  private static final ObjectInspector LONG_OBJECT_INSPECTOR = PrimitiveObjectInspectorFactory
+          .getPrimitiveJavaObjectInspector(PrimitiveObjectInspector.PrimitiveCategory.LONG);
+  private static final ObjectInspector LONG_LIST_OBJECT_INSPECTOR = ObjectInspectorFactory
+          .getStandardListObjectInspector(LONG_OBJECT_INSPECTOR);
+  private static final ObjectInspector STRING_LIST_OBJECT_INSPECTOR = ObjectInspectorFactory
+          .getStandardListObjectInspector(STRING_OBJECT_INSPECTOR);
+
+  private static final List<String> TEST_STRINGS = Lists.newArrayList("123", "456", "7890", "98765", "4321");
+  private static final List<Long> TEST_LONGS = new ArrayList<>();
+  static {
+    for (String l : TEST_STRINGS) {
+      TEST_LONGS.add(Long.parseLong(l));
+    }
+  }
+  private static final double TEST_DOUBLE = 123.45;
+
   @Test
   public void testString() {
-    String val = "boblablah";
-    AttributeValue expected = new AttributeValue().withS(val);
-    for (Object o : new Object[]{val, new Text(val)}){
-      AttributeValue actual = HiveDynamoDBTypeUtil.parseObject(o);
-      assertEquals(expected, actual);
+    String val = TEST_STRINGS.get(0);
+    HiveDynamoDBType ddType = HiveDynamoDBTypeFactory.getTypeObjectFromHiveType(serdeConstants.STRING_TYPE_NAME);
+    AttributeValue expectedAV = new AttributeValue().withS(val);
+    LazyString ls = new LazyString(LazyPrimitiveObjectInspectorFactory
+            .getLazyStringObjectInspector(false, (byte) 0));
+    initLazyObject(ls, val.getBytes(), 0, val.length());
+
+    for (Object o : new Object[]{val, new Text(val), ls}) {
+      AttributeValue actualAV = ddType.getDynamoDBData(o, STRING_OBJECT_INSPECTOR);
+      assertEquals(expectedAV, actualAV);
+      Object actualStr = ddType.getHiveData(actualAV, serdeConstants.STRING_TYPE_NAME);
+      assertEquals(val, actualStr);
     }
   }
 
   /**
    * See: https://github.com/apache/hive/blob/ae008b79b5d52ed6a38875b73025a505725828eb/serde/src/test/org/apache/hadoop/hive/serde2/lazy/TestLazyPrimitive.java#L265
    */
-  public static void initLazyObject(LazyObject lo, byte[] data, int start,
-                                    int length) {
+  private static void initLazyObject(LazyObject lo, byte[] data, int start, int length) {
     ByteArrayRef b = new ByteArrayRef();
     b.setData(data);
     lo.init(b, start, length);
   }
 
   @Test
-  public void testNumber() {
-    String val = "123.45";
-    AttributeValue expected = new AttributeValue().withN(val);
+  public void testDouble() {
+    double val = TEST_DOUBLE;
+    String valString = Double.toString(val);
+    HiveDynamoDBType ddType = HiveDynamoDBTypeFactory.getTypeObjectFromHiveType(serdeConstants.DOUBLE_TYPE_NAME);
+    AttributeValue expectedAV = new AttributeValue().withN(valString);
+    AttributeValue actualAV = ddType.getDynamoDBData(val, DOUBLE_OBJECT_INSPECTOR);
+    assertEquals(expectedAV, actualAV);
+    Object actualDouble = ddType.getHiveData(actualAV, serdeConstants.DOUBLE_TYPE_NAME);
+    assertEquals(val, actualDouble);
+
     LazyDouble ld = new LazyDouble(LAZY_DOUBLE_OBJECT_INSPECTOR);
-    initLazyObject(ld, val.getBytes(), 0, val.length());
-    AttributeValue actual = HiveDynamoDBTypeUtil.parseObject(ld);
-    assertEquals(expected, actual);
+    initLazyObject(ld, valString.getBytes(), 0, valString.length());
+    actualAV = ddType.getDynamoDBData(ld, LAZY_DOUBLE_OBJECT_INSPECTOR);
+    actualDouble = ddType.getHiveData(actualAV, serdeConstants.DOUBLE_TYPE_NAME);
+    assertEquals(val, actualDouble);
+  }
+
+  @Test
+  public void testLong() {
+    long val = TEST_LONGS.get(0);
+    String valString = Long.toString(val);
+    HiveDynamoDBType ddType = HiveDynamoDBTypeFactory.getTypeObjectFromHiveType(serdeConstants.BIGINT_TYPE_NAME);
+    AttributeValue expectedAV = new AttributeValue().withN(valString);
+    AttributeValue actualAV = ddType.getDynamoDBData(val, LONG_OBJECT_INSPECTOR);
+    assertEquals(expectedAV, actualAV);
+    Object actualLong = ddType.getHiveData(actualAV, serdeConstants.BIGINT_TYPE_NAME);
+    assertEquals(val, actualLong);
+
+    LazyLong ll = new LazyLong(LAZY_LONG_OBJECT_INSPECTOR);
+    initLazyObject(ll, valString.getBytes(), 0, valString.length());
+    actualAV = ddType.getDynamoDBData(ll, LAZY_LONG_OBJECT_INSPECTOR);
+    assertEquals(expectedAV, actualAV);
+    actualLong = ddType.getHiveData(actualAV, serdeConstants.BIGINT_TYPE_NAME);
+    assertEquals(val, actualLong);
+  }
+
+  @Test
+  public void testList() {
+    List<AttributeValue> longAVList = new ArrayList<>();
+    List<AttributeValue> strAVList = new ArrayList<>();
+    for (String str : TEST_STRINGS) {
+      longAVList.add(new AttributeValue().withN(str));
+      strAVList.add(new AttributeValue(str));
+    }
+    HiveDynamoDBType ddType = HiveDynamoDBListTypeFactory
+            .getTypeObjectFromHiveType(DerivedHiveTypeConstants.BIGINT_ARRAY_TYPE_NAME);
+    AttributeValue expectedAV = new AttributeValue().withL(longAVList);
+    AttributeValue actualAV = ddType.getDynamoDBData(TEST_LONGS, LONG_LIST_OBJECT_INSPECTOR);
+    assertEquals(expectedAV, actualAV);
+    Object actualList = ddType.getHiveData(actualAV, DerivedHiveTypeConstants.BIGINT_ARRAY_TYPE_NAME);
+    assertEquals(TEST_LONGS, actualList);
+
+    ddType = HiveDynamoDBListTypeFactory.getTypeObjectFromHiveType(DerivedHiveTypeConstants.STRING_ARRAY_TYPE_NAME);
+    expectedAV = new AttributeValue().withL(strAVList);
+    actualAV = ddType.getDynamoDBData(TEST_STRINGS, STRING_LIST_OBJECT_INSPECTOR);
+    assertEquals(expectedAV, actualAV);
+    actualList = ddType.getHiveData(actualAV, DerivedHiveTypeConstants.STRING_ARRAY_TYPE_NAME);
+    assertEquals(TEST_STRINGS, actualList);
+  }
+
+  @Test
+  public void testSet() {
+    HiveDynamoDBType ddType = HiveDynamoDBTypeFactory
+            .getTypeObjectFromHiveType(DerivedHiveTypeConstants.BIGINT_ARRAY_TYPE_NAME);
+    AttributeValue expectedAV = new AttributeValue().withNS(TEST_STRINGS);
+    AttributeValue actualAV = ddType.getDynamoDBData(TEST_LONGS, LONG_LIST_OBJECT_INSPECTOR);
+    assertEquals(expectedAV, actualAV);
+    Object actualList = ddType.getHiveData(actualAV, DerivedHiveTypeConstants.BIGINT_ARRAY_TYPE_NAME);
+    assertEquals(TEST_LONGS, actualList);
+
+    ddType = HiveDynamoDBTypeFactory.getTypeObjectFromHiveType(DerivedHiveTypeConstants.STRING_ARRAY_TYPE_NAME);
+    expectedAV = new AttributeValue().withSS(TEST_STRINGS);
+    actualAV = ddType.getDynamoDBData(TEST_STRINGS, STRING_LIST_OBJECT_INSPECTOR);
+    assertEquals(expectedAV, actualAV);
+    actualList = ddType.getHiveData(actualAV, DerivedHiveTypeConstants.STRING_ARRAY_TYPE_NAME);
+    assertEquals(TEST_STRINGS, actualList);
   }
 
   @Test


### PR DESCRIPTION
*Issue #, if available:*
Issue #82 : Currently, DynamoDB lists show up as `null` in Hive tables due to issues in parsing logic.

*Description of changes:*

The following changes fix these issues so that the connector can properly support DynamoDB lists, including nested lists:
1. Include alternate `DynamoDBListObjectInspector` to map arrays to lists.
2. Infer element type of list and use element type object to parse elements when serializing and deserializing.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
