### PR TITLE
Add support for Hive structs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Currently, the connector supports the following data types:
 | array | list (L) | number set (NS), string set (SS), binary set (BS) |
 | map<string,string> | item (ITEM) | map (M) |
 | map<string,?> | map (M) | |
+| struct | map (M) | |
 
 ### Hive StorageHandler Implementation
 For more information, see [Hive Commands Examples for Exporting, Importing, and Querying Data in

--- a/emr-dynamodb-hive/src/test/java/org/apache/hadoop/hive/dynamodb/DynamoDBObjectInspectorTest.java
+++ b/emr-dynamodb-hive/src/test/java/org/apache/hadoop/hive/dynamodb/DynamoDBObjectInspectorTest.java
@@ -43,13 +43,19 @@ public class DynamoDBObjectInspectorTest {
   private static final TypeInfo LIST_MAP_TYPE_INFO = TypeInfoFactory.getMapTypeInfo(STRING_TYPE_INFO,
       STRING_LIST_TYPE_INFO);
 
+  private static final List<String> PRIMITIVE_FIELDS = Lists.newArrayList("animal", "height", "weight", "endangered");
+  private static final List<TypeInfo> PRIMITIVE_TYPE_INFOS = Lists.newArrayList(STRING_TYPE_INFO,
+      DOUBLE_TYPE_INFO, LONG_TYPE_INFO, BOOLEAN_TYPE_INFO);
+  private static final List<String> PRIMITIVE_STRING_DATA = Lists.newArrayList("giraffe", "5.5", "1360", "true");
+  private static final TypeInfo PRIMITIVE_STRUCT_TYPE_INFO = TypeInfoFactory
+      .getStructTypeInfo(PRIMITIVE_FIELDS, PRIMITIVE_TYPE_INFOS);
+
   @Test
   public void testPrimitives() {
-    List<String> attributeNames = Lists.newArrayList("animal", "height", "weight", "endangered");
-    List<TypeInfo> colTypeInfos = Lists.newArrayList(STRING_TYPE_INFO, DOUBLE_TYPE_INFO, LONG_TYPE_INFO,
-        BOOLEAN_TYPE_INFO);
+    List<String> attributeNames = PRIMITIVE_FIELDS;
+    List<TypeInfo> colTypeInfos = PRIMITIVE_TYPE_INFOS;
 
-    List<String> data = Lists.newArrayList("giraffe", "5.5", "1360", "true");
+    List<String> data = PRIMITIVE_STRING_DATA;
 
     List<Object> expectedRowData = Lists.newArrayList();
     expectedRowData.add(data.get(0));
@@ -151,18 +157,51 @@ public class DynamoDBObjectInspectorTest {
   }
 
   @Test
+  public void testStruct() {
+    List<String> attributeNames = Lists.newArrayList("struct", "data");
+    List<TypeInfo> colTypeInfos = Lists.newArrayList(STRING_TYPE_INFO, PRIMITIVE_STRUCT_TYPE_INFO);
+
+    String struct = "animal";
+    List<String> data = PRIMITIVE_STRING_DATA;
+
+    List<Object> structData = Lists.newArrayList();
+    structData.add(data.get(0));
+    structData.add(Double.parseDouble(data.get(1)));
+    structData.add(Long.parseLong(data.get(2)));
+    structData.add(Boolean.valueOf(data.get(3)));
+
+    List<Object> expectedRowData = Lists.newArrayList();
+    expectedRowData.add(struct);
+    expectedRowData.add(structData);
+
+    Map<String, AttributeValue> dataAV = Maps.newHashMap();
+    dataAV.put(PRIMITIVE_FIELDS.get(0), new AttributeValue(data.get(0)));
+    dataAV.put(PRIMITIVE_FIELDS.get(1), new AttributeValue().withN(data.get(1)));
+    dataAV.put(PRIMITIVE_FIELDS.get(2), new AttributeValue().withN(data.get(2)));
+    dataAV.put(PRIMITIVE_FIELDS.get(3), new AttributeValue().withBOOL(Boolean.valueOf(data.get(3))));
+
+    Map<String, AttributeValue> itemMap = Maps.newHashMap();
+    itemMap.put(attributeNames.get(0), new AttributeValue(struct));
+    itemMap.put(attributeNames.get(1), new AttributeValue().withM(dataAV));
+
+    List<Object> actualRowData = getDeserializedRow(attributeNames, colTypeInfos, itemMap);
+
+    assertEquals(expectedRowData, actualRowData);
+  }
+
+  @Test
   public void testItem() {
     List<String> colNames = Lists.newArrayList("ddbitem");
     List<TypeInfo> colTypeInfos = Lists.newArrayList(STRING_MAP_TYPE_INFO);
 
-    List<String> attributeNames = Lists.newArrayList("animal", "height", "weight", "endangered");
+    List<String> attributeNames = PRIMITIVE_FIELDS;
     List<String> attributeTypes = DynamoDBTestUtils.toAttributeValueFieldFormatList(
         DynamoDBTypeConstants.STRING,
         DynamoDBTypeConstants.NUMBER,
         DynamoDBTypeConstants.NUMBER,
         DynamoDBTypeConstants.BOOLEAN
     );
-    List<String> data = Lists.newArrayList("giraffe", "5.5", "1360", "true");
+    List<String> data = PRIMITIVE_STRING_DATA;
     Map<String, String> colItemMap = Maps.newHashMap();
     for (int i = 0; i < attributeNames.size(); i++) {
       String type = attributeTypes.get(i);

--- a/emr-dynamodb-hive/src/test/java/org/apache/hadoop/hive/dynamodb/DynamoDBSerDeTest.java
+++ b/emr-dynamodb-hive/src/test/java/org/apache/hadoop/hive/dynamodb/DynamoDBSerDeTest.java
@@ -55,13 +55,19 @@ public class DynamoDBSerDeTest {
   private static final ObjectInspector LIST_MAP_OBJECT_INSPECTOR = ObjectInspectorFactory
       .getStandardMapObjectInspector(STRING_OBJECT_INSPECTOR, STRING_LIST_OBJECT_INSPECTOR);
 
+  private static final List<String> PRIMITIVE_FIELDS = Lists.newArrayList("animal", "height", "weight", "endangered");
+  private static final List<ObjectInspector> PRIMITIVE_OIS = Lists.newArrayList(STRING_OBJECT_INSPECTOR,
+      DOUBLE_OBJECT_INSPECTOR, LONG_OBJECT_INSPECTOR, BOOLEAN_OBJECT_INSPECTOR);
+  private static final List<String> PRIMITIVE_STRING_DATA = Lists.newArrayList("giraffe", "5.5", "1360", "true");
+  private static final ObjectInspector PRIMITIVE_STRUCT_OBJECT_INSPECTOR = ObjectInspectorFactory
+      .getStandardStructObjectInspector(PRIMITIVE_FIELDS, PRIMITIVE_OIS);
+
   @Test
   public void testPrimitives() throws SerDeException {
-    List<String> attributeNames = Lists.newArrayList("animal", "height", "weight", "endangered");
-    List<ObjectInspector> colOIs = Lists.newArrayList(STRING_OBJECT_INSPECTOR, DOUBLE_OBJECT_INSPECTOR,
-        LONG_OBJECT_INSPECTOR, BOOLEAN_OBJECT_INSPECTOR);
+    List<String> attributeNames = PRIMITIVE_FIELDS;
+    List<ObjectInspector> colOIs = PRIMITIVE_OIS;
 
-    List<String> data = Lists.newArrayList("giraffe", "5.5", "1360", "true");
+    List<String> data = PRIMITIVE_STRING_DATA;
 
     Map<String, AttributeValue> expectedItemMap = Maps.newHashMap();
     expectedItemMap.put(attributeNames.get(0), new AttributeValue(data.get(0)));
@@ -170,18 +176,50 @@ public class DynamoDBSerDeTest {
   }
 
   @Test
+  public void testStruct() throws SerDeException {
+    List<String> attributeNames = Lists.newArrayList("struct", "data");
+    List<ObjectInspector> colOIs = Lists.newArrayList(STRING_OBJECT_INSPECTOR, PRIMITIVE_STRUCT_OBJECT_INSPECTOR);
+
+    String struct = "animal";
+    List<String> data = PRIMITIVE_STRING_DATA;
+    Map<String, AttributeValue> dataAV = Maps.newHashMap();
+    dataAV.put(PRIMITIVE_FIELDS.get(0), new AttributeValue(data.get(0)));
+    dataAV.put(PRIMITIVE_FIELDS.get(1), new AttributeValue().withN(data.get(1)));
+    dataAV.put(PRIMITIVE_FIELDS.get(2), new AttributeValue().withN(data.get(2)));
+    dataAV.put(PRIMITIVE_FIELDS.get(3), new AttributeValue().withBOOL(Boolean.valueOf(data.get(3))));
+
+    Map<String, AttributeValue> expectedItemMap = Maps.newHashMap();
+    expectedItemMap.put(attributeNames.get(0), new AttributeValue(struct));
+    expectedItemMap.put(attributeNames.get(1), new AttributeValue().withM(dataAV));
+
+    List<Object> structData = Lists.newArrayList();
+    structData.add(data.get(0));
+    structData.add(Double.parseDouble(data.get(1)));
+    structData.add(Long.parseLong(data.get(2)));
+    structData.add(Boolean.valueOf(data.get(3)));
+
+    List<Object> rowData = Lists.newArrayList();
+    rowData.add(struct);
+    rowData.add(structData);
+
+    Map<String, AttributeValue> actualItemMap = getSerializedItem(attributeNames, colOIs, rowData);
+
+    assertEquals(expectedItemMap, actualItemMap);
+  }
+
+  @Test
   public void testItem() throws SerDeException {
     List<String> colNames = Lists.newArrayList("ddbitem");
     List<ObjectInspector> colOIs = Lists.newArrayList(STRING_MAP_OBJECT_INSPECTOR);
 
-    List<String> attributeNames = Lists.newArrayList("animal", "height", "weight", "endangered");
+    List<String> attributeNames = PRIMITIVE_FIELDS;
     List<String> attributeTypes = DynamoDBTestUtils.toAttributeValueFieldFormatList(
         DynamoDBTypeConstants.STRING,
         DynamoDBTypeConstants.NUMBER,
         DynamoDBTypeConstants.NUMBER,
         DynamoDBTypeConstants.BOOLEAN
     );
-    List<String> data = Lists.newArrayList("giraffe", "5.5", "1360", "true");
+    List<String> data = PRIMITIVE_STRING_DATA;
     Map<String, AttributeValue> expectedItemMap = Maps.newHashMap();
     expectedItemMap.put(attributeNames.get(0), new AttributeValue(data.get(0)));
     expectedItemMap.put(attributeNames.get(1), new AttributeValue().withN(data.get(1)));

--- a/emr-dynamodb-hive/src/test/java/org/apache/hadoop/hive/dynamodb/type/HiveDynamoDBTypeTest.java
+++ b/emr-dynamodb-hive/src/test/java/org/apache/hadoop/hive/dynamodb/type/HiveDynamoDBTypeTest.java
@@ -225,6 +225,27 @@ public class HiveDynamoDBTypeTest {
   }
 
   @Test
+  public void testStruct() {
+    List<Object> struct = Lists.newArrayList((Object) STRING_LIST.get(0), LONG_LIST.get(1), TEST_DOUBLE);
+    Map<String, AttributeValue> structAVMap = new HashMap<>();
+    structAVMap.put(STRING_LIST.get(0), new AttributeValue(STRING_LIST.get(0)));
+    structAVMap.put(STRING_LIST.get(1), new AttributeValue().withN(Long.toString(LONG_LIST.get(1))));
+    structAVMap.put(STRING_LIST.get(2), new AttributeValue().withN(Double.toString(TEST_DOUBLE)));
+    List<String> structFieldNames = STRING_LIST.subList(0, 3);
+    List<ObjectInspector> structFieldOIs = Lists.newArrayList(STRING_OBJECT_INSPECTOR, LONG_OBJECT_INSPECTOR,
+            DOUBLE_OBJECT_INSPECTOR);
+    ObjectInspector structObjectInspector = ObjectInspectorFactory
+            .getStandardStructObjectInspector(structFieldNames, structFieldOIs);
+
+    HiveDynamoDBType ddType = HiveDynamoDBTypeFactory.getTypeObjectFromHiveType(structObjectInspector);
+    AttributeValue expectedAV = new AttributeValue().withM(structAVMap);
+    AttributeValue actualAV = ddType.getDynamoDBData(struct, structObjectInspector);
+    assertEquals(expectedAV, actualAV);
+    Object actualStruct = ddType.getHiveData(actualAV, structObjectInspector);
+    assertEquals(struct, actualStruct);
+  }
+
+  @Test
   public void testMultipleTypeList() {
     List<AttributeValue> avList = new ArrayList<>();
     avList.add(new AttributeValue(STRING_LIST.get(0)));


### PR DESCRIPTION
*Description of changes:*

Add support for users to read or write Hive structs as DynamoDB maps.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
