### PR TITLE
Add support for DynamoDB null type

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Currently, the connector supports the following data types:
 | map<string,?> | map (M) | |
 | struct | map (M) | |
 
+The connector can serialize null values as DynamoDB null type (NULL).
+
 ### Hive StorageHandler Implementation
 For more information, see [Hive Commands Examples for Exporting, Importing, and Querying Data in
 DynamoDB][hive-commands-emr-dev-guide] in the *[Amazon DynamoDB Developer Guide][dynamodb-dev-guide]*.
@@ -42,7 +44,7 @@ This simple tool that makes use of the InputFormat and OutputFormat implementati
 
 ### Supported Versions
 Currently the project builds against Hive 2.3.0, 1.2.1, and 1.0.0. Set this by using the `hive1.version`,
-`hive1.2.version and `hive2.version` properties in the root Maven `pom.xml`, respectively.
+`hive1.2.version` and `hive2.version` properties in the root Maven `pom.xml`, respectively.
 
 ## How to Build
 After cloning, run `mvn clean install`.
@@ -60,9 +62,12 @@ TBLPROPERTIES (
     "dynamodb.column.mapping" =
         "hive_column1_name:dynamodb_attribute1_name,hive_column2_name:dynamodb_attribute2_name",
     "dynamodb.type.mapping" =
-        "hive_column1_name:dynamodb_attribute1_type_abbreviation"
+        "hive_column1_name:dynamodb_attribute1_type_abbreviation",
+    "dynamodb.null.serialization" = "true"
 );
 ```
+
+`dynamodb.type.mapping` and `dynamodb.null.serialization` are optional parameters.
 
 ## Example: Input/Output Formats with Spark
 Using the DynamoDBInputFormat and DynamoDBOutputFormat classes with `spark-shell`:

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBConstants.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBConstants.java
@@ -33,6 +33,8 @@ public interface DynamoDBConstants {
   // Table constants
   String DYNAMODB_COLUMN_MAPPING = "dynamodb.column.mapping";
   String DYNAMODB_TYPE_MAPPING = "dynamodb.type.mapping";
+  String DYNAMODB_NULL_SERIALIZATION = "dynamodb.null.serialization";
+
   // JobConf constants
   String DYNAMODB_FILTER_PUSHDOWN = "dynamodb.filter.pushdown";
 

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/type/DynamoDBNullType.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/type/DynamoDBNullType.java
@@ -1,0 +1,21 @@
+package org.apache.hadoop.dynamodb.type;
+
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import org.apache.hadoop.dynamodb.key.DynamoDBKey;
+
+public class DynamoDBNullType implements DynamoDBType {
+  @Override
+  public AttributeValue getAttributeValue(String... values) {
+    return new AttributeValue().withNULL(true);
+  }
+
+  @Override
+  public String getDynamoDBType() {
+    return DynamoDBTypeConstants.NULL;
+  }
+
+  @Override
+  public DynamoDBKey getKey(String key) {
+    throw new RuntimeException("Unexpected type " + getDynamoDBType());
+  }
+}

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/type/DynamoDBTypeConstants.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/type/DynamoDBTypeConstants.java
@@ -18,6 +18,7 @@ public final class DynamoDBTypeConstants {
   public static final String ITEM = "ITEM";
   public static final String LIST = "L";
   public static final String MAP = "M";
+  public static final String NULL = "NULL";
   public static final String NUMBER_SET = "NS";
   public static final String NUMBER = "N";
   public static final String STRING_SET = "SS";

--- a/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/DynamoDBStorageHandler.java
+++ b/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/DynamoDBStorageHandler.java
@@ -165,6 +165,11 @@ public class DynamoDBStorageHandler
             .toJsonString(hiveToDynamoDBTypeMapping));
       }
 
+      boolean hiveToDynamoDBNullSerialization = Boolean
+          .parseBoolean(tableDesc.getProperties().getProperty(DynamoDBConstants.DYNAMODB_NULL_SERIALIZATION));
+      jobProperties.put(DynamoDBConstants.DYNAMODB_NULL_SERIALIZATION,
+          Boolean.toString(hiveToDynamoDBNullSerialization));
+
       if (tableDesc.getProperties().getProperty(DynamoDBConstants.THROUGHPUT_READ_PERCENT)
           != null) {
         jobProperties.put(DynamoDBConstants.THROUGHPUT_READ_PERCENT, tableDesc.getProperties()

--- a/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/type/HiveDynamoDBBinarySetType.java
+++ b/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/type/HiveDynamoDBBinarySetType.java
@@ -28,9 +28,11 @@ import java.util.List;
 public class HiveDynamoDBBinarySetType extends DynamoDBBinarySetType implements HiveDynamoDBType {
 
   @Override
-  public AttributeValue getDynamoDBData(Object data, ObjectInspector objectInspector) {
+  public AttributeValue getDynamoDBData(Object data, ObjectInspector objectInspector, boolean nullSerialization) {
     List<ByteBuffer> values = DynamoDBDataParser.getByteBuffers(data, objectInspector, getDynamoDBType());
-    return (values == null || values.isEmpty()) ? null : new AttributeValue().withBS(values);
+    return (values == null || values.isEmpty()) ?
+        DynamoDBDataParser.getNullAttribute(nullSerialization) :
+        new AttributeValue().withBS(values);
   }
 
   @Override

--- a/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/type/HiveDynamoDBBinaryType.java
+++ b/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/type/HiveDynamoDBBinaryType.java
@@ -25,9 +25,9 @@ import java.nio.ByteBuffer;
 public class HiveDynamoDBBinaryType extends DynamoDBBinaryType implements HiveDynamoDBType {
 
   @Override
-  public AttributeValue getDynamoDBData(Object data, ObjectInspector objectInspector) {
+  public AttributeValue getDynamoDBData(Object data, ObjectInspector objectInspector, boolean nullSerialization) {
     ByteBuffer value = DynamoDBDataParser.getByteBuffer(data, objectInspector);
-    return new AttributeValue().withB(value);
+    return value == null ? DynamoDBDataParser.getNullAttribute(nullSerialization) : new AttributeValue().withB(value);
   }
 
   @Override

--- a/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/type/HiveDynamoDBItemType.java
+++ b/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/type/HiveDynamoDBItemType.java
@@ -42,7 +42,7 @@ public class HiveDynamoDBItemType implements DynamoDBItemType, HiveDynamoDBType 
   }
 
   @Override
-  public AttributeValue getDynamoDBData(Object data, ObjectInspector objectInspector) {
+  public AttributeValue getDynamoDBData(Object data, ObjectInspector objectInspector, boolean nullSerialization) {
     throw new UnsupportedOperationException("DynamoDBItemType does not support this operation.");
   }
 

--- a/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/type/HiveDynamoDBListType.java
+++ b/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/type/HiveDynamoDBListType.java
@@ -23,9 +23,9 @@ import java.util.List;
 public class HiveDynamoDBListType extends DynamoDBListType implements HiveDynamoDBType {
 
   @Override
-  public AttributeValue getDynamoDBData(Object data, ObjectInspector objectInspector) {
-    List<AttributeValue> values = DynamoDBDataParser.getListAttribute(data, objectInspector);
-    return values == null ? null : new AttributeValue().withL(values);
+  public AttributeValue getDynamoDBData(Object data, ObjectInspector objectInspector, boolean nullSerialization) {
+    List<AttributeValue> values = DynamoDBDataParser.getListAttribute(data, objectInspector, nullSerialization);
+    return values == null ? DynamoDBDataParser.getNullAttribute(nullSerialization) : new AttributeValue().withL(values);
   }
 
   @Override

--- a/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/type/HiveDynamoDBMapType.java
+++ b/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/type/HiveDynamoDBMapType.java
@@ -25,9 +25,9 @@ import java.util.Map;
 public class HiveDynamoDBMapType extends DynamoDBMapType implements HiveDynamoDBType {
 
   @Override
-  public AttributeValue getDynamoDBData(Object data, ObjectInspector objectInspector) {
-    Map<String, AttributeValue> values = DynamoDBDataParser.getMapAttribute(data, objectInspector);
-    return values == null ? null : new AttributeValue().withM(values);
+  public AttributeValue getDynamoDBData(Object data, ObjectInspector objectInspector, boolean nullSerialization) {
+    Map<String, AttributeValue> values = DynamoDBDataParser.getMapAttribute(data, objectInspector, nullSerialization);
+    return values == null ? DynamoDBDataParser.getNullAttribute(nullSerialization) : new AttributeValue().withM(values);
   }
 
   @Override

--- a/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/type/HiveDynamoDBNullType.java
+++ b/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/type/HiveDynamoDBNullType.java
@@ -1,34 +1,31 @@
 package org.apache.hadoop.hive.dynamodb.type;
 
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
-import org.apache.hadoop.dynamodb.type.DynamoDBBooleanType;
+import org.apache.hadoop.dynamodb.type.DynamoDBNullType;
 import org.apache.hadoop.hive.dynamodb.util.DynamoDBDataParser;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
 
-public class HiveDynamoDBBooleanType extends DynamoDBBooleanType implements HiveDynamoDBType {
+public class HiveDynamoDBNullType extends DynamoDBNullType implements HiveDynamoDBType {
 
   @Override
   public AttributeValue getDynamoDBData(Object data, ObjectInspector objectInspector, boolean nullSerialization) {
-    Boolean value = DynamoDBDataParser.getBoolean(data, objectInspector);
-    return value == null ?
-        DynamoDBDataParser.getNullAttribute(nullSerialization) :
-        new AttributeValue().withBOOL(value);
+    throw new UnsupportedOperationException(getClass().toString() + " does not support this operation.");
   }
 
   @Override
   public TypeInfo getSupportedHiveType() {
-    return TypeInfoFactory.booleanTypeInfo;
+    throw new UnsupportedOperationException(getClass().toString() + " does not support this operation.");
   }
 
   @Override
   public boolean supportsHiveType(TypeInfo typeInfo) {
-    return typeInfo.equals(getSupportedHiveType());
+    throw new UnsupportedOperationException(getClass().toString() + " does not support this operation.");
   }
 
   @Override
   public Object getHiveData(AttributeValue data, ObjectInspector objectInspector) {
-    return data.getBOOL();
+    return null;
   }
 }

--- a/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/type/HiveDynamoDBNumberSetType.java
+++ b/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/type/HiveDynamoDBNumberSetType.java
@@ -25,9 +25,11 @@ import java.util.List;
 public class HiveDynamoDBNumberSetType extends DynamoDBNumberSetType implements HiveDynamoDBType {
 
   @Override
-  public AttributeValue getDynamoDBData(Object data, ObjectInspector objectInspector) {
+  public AttributeValue getDynamoDBData(Object data, ObjectInspector objectInspector, boolean nullSerialization) {
     List<String> values = DynamoDBDataParser.getSetAttribute(data, objectInspector, getDynamoDBType());
-    return (values == null || values.isEmpty()) ? null : new AttributeValue().withNS(values);
+    return (values == null || values.isEmpty()) ?
+        DynamoDBDataParser.getNullAttribute(nullSerialization) :
+        new AttributeValue().withNS(values);
   }
 
   @Override

--- a/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/type/HiveDynamoDBNumberType.java
+++ b/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/type/HiveDynamoDBNumberType.java
@@ -23,9 +23,9 @@ import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
 public class HiveDynamoDBNumberType extends DynamoDBNumberType implements HiveDynamoDBType {
 
   @Override
-  public AttributeValue getDynamoDBData(Object data, ObjectInspector objectInspector) {
+  public AttributeValue getDynamoDBData(Object data, ObjectInspector objectInspector, boolean nullSerialization) {
     String value = DynamoDBDataParser.getNumber(data, objectInspector);
-    return value == null ? null : new AttributeValue().withN(value);
+    return value == null ? DynamoDBDataParser.getNullAttribute(nullSerialization) : new AttributeValue().withN(value);
   }
 
   @Override

--- a/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/type/HiveDynamoDBStringSetType.java
+++ b/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/type/HiveDynamoDBStringSetType.java
@@ -25,9 +25,11 @@ import java.util.List;
 public class HiveDynamoDBStringSetType extends DynamoDBStringSetType implements HiveDynamoDBType {
 
   @Override
-  public AttributeValue getDynamoDBData(Object data, ObjectInspector objectInspector) {
+  public AttributeValue getDynamoDBData(Object data, ObjectInspector objectInspector, boolean nullSerialization) {
     List<String> values = DynamoDBDataParser.getSetAttribute(data, objectInspector, getDynamoDBType());
-    return (values == null || values.isEmpty()) ? null : new AttributeValue().withSS(values);
+    return (values == null || values.isEmpty()) ?
+        DynamoDBDataParser.getNullAttribute(nullSerialization) :
+        new AttributeValue().withSS(values);
   }
 
   @Override

--- a/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/type/HiveDynamoDBStringType.java
+++ b/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/type/HiveDynamoDBStringType.java
@@ -22,9 +22,9 @@ import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
 
 public class HiveDynamoDBStringType extends DynamoDBStringType implements HiveDynamoDBType {
   @Override
-  public AttributeValue getDynamoDBData(Object data, ObjectInspector objectInspector) {
+  public AttributeValue getDynamoDBData(Object data, ObjectInspector objectInspector, boolean nullSerialization) {
     String value = DynamoDBDataParser.getString(data, objectInspector);
-    return value == null ? null : new AttributeValue(value);
+    return value == null ? DynamoDBDataParser.getNullAttribute(nullSerialization) : new AttributeValue(value);
   }
 
   @Override

--- a/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/type/HiveDynamoDBType.java
+++ b/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/type/HiveDynamoDBType.java
@@ -22,7 +22,7 @@ public interface HiveDynamoDBType extends DynamoDBType {
 
   Object getHiveData(AttributeValue data, ObjectInspector objectInspector);
 
-  AttributeValue getDynamoDBData(Object data, ObjectInspector objectInspector);
+  AttributeValue getDynamoDBData(Object data, ObjectInspector objectInspector, boolean nullSerialization);
 
   TypeInfo getSupportedHiveType();
 

--- a/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/type/HiveDynamoDBTypeFactory.java
+++ b/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/type/HiveDynamoDBTypeFactory.java
@@ -44,7 +44,8 @@ public class HiveDynamoDBTypeFactory extends DynamoDBTypeFactory {
   private static final Set<HiveDynamoDBType> ALTERNATE_HIVE_DYNAMODB_TYPES = Sets.newHashSet(
       new HiveDynamoDBStringSetType(),
       new HiveDynamoDBBinarySetType(),
-      new HiveDynamoDBNumberSetType()
+      new HiveDynamoDBNumberSetType(),
+      new HiveDynamoDBNullType()
   );
 
   private static final Map<TypeInfo, HiveDynamoDBType> SIMPLE_HIVE_DYNAMODB_TYPES_MAP = Maps.newHashMap();

--- a/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/util/HiveDynamoDBUtil.java
+++ b/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/util/HiveDynamoDBUtil.java
@@ -73,6 +73,10 @@ public final class HiveDynamoDBUtil {
     return typeMappings;
   }
 
+  public static boolean getHiveToDynamoDBNullSerialization(Properties tbl) {
+    return Boolean.parseBoolean(tbl.getProperty(DynamoDBConstants.DYNAMODB_NULL_SERIALIZATION));
+  }
+
   public static String toJsonString(Map<String, String> dynamoDBTypeMapping) {
     return gson.toJson(dynamoDBTypeMapping, MAP_TYPE);
   }

--- a/emr-dynamodb-hive/src/test/java/org/apache/hadoop/hive/dynamodb/DynamoDBObjectInspectorTest.java
+++ b/emr-dynamodb-hive/src/test/java/org/apache/hadoop/hive/dynamodb/DynamoDBObjectInspectorTest.java
@@ -74,6 +74,25 @@ public class DynamoDBObjectInspectorTest {
   }
 
   @Test
+  public void testNull() {
+    List<String> attributeNames = PRIMITIVE_FIELDS.subList(0, 2);
+    List<TypeInfo> colTypeInfos = PRIMITIVE_TYPE_INFOS.subList(0, 2);
+
+    List<String> data = Lists.newArrayList(PRIMITIVE_STRING_DATA.subList(0, 2));
+    data.set(1, null);
+
+    List<Object> expectedRowData = Lists.newArrayList();
+    expectedRowData.addAll(data);
+
+    Map<String, AttributeValue> itemMap = Maps.newHashMap();
+    itemMap.put(attributeNames.get(0), new AttributeValue(data.get(0)));
+    itemMap.put(attributeNames.get(1), new AttributeValue().withNULL(true));
+    List<Object> actualRowData = getDeserializedRow(attributeNames, colTypeInfos, itemMap);
+
+    assertEquals(expectedRowData, actualRowData);
+  }
+
+  @Test
   public void testArray() {
     List<String> attributeNames = Lists.newArrayList("list", "items");
     List<TypeInfo> colTypeInfos = Lists.newArrayList(STRING_TYPE_INFO, STRING_LIST_TYPE_INFO);

--- a/emr-dynamodb-hive/src/test/java/org/apache/hadoop/hive/dynamodb/DynamoDBStorageHandlerTest.java
+++ b/emr-dynamodb-hive/src/test/java/org/apache/hadoop/hive/dynamodb/DynamoDBStorageHandlerTest.java
@@ -287,6 +287,28 @@ public class DynamoDBStorageHandlerTest {
     storageHandler.checkTableSchemaType(description, table);
   }
 
+  @Test
+  public void testCheckTableSchemaNullSerializationValid() throws MetaException {
+    TableDescription description = getHashRangeTable();
+
+    Table table = new Table();
+    Map<String, String> parameters = Maps.newHashMap();
+    parameters.put(DynamoDBConstants.DYNAMODB_COLUMN_MAPPING, "col1:dynamo_col1$," +
+        "col2:dynamo_col2#,hashKey:hashKey");
+    parameters.put(DynamoDBConstants.DYNAMODB_NULL_SERIALIZATION, "true");
+    table.setParameters(parameters);
+    StorageDescriptor sd = new StorageDescriptor();
+    List<FieldSchema> cols = Lists.newArrayList();
+    cols.add(new FieldSchema("col1", "string", ""));
+    cols.add(new FieldSchema("col2", "array<bigint>", ""));
+    cols.add(new FieldSchema("hashKey", "string", ""));
+    sd.setCols(cols);
+    table.setSd(sd);
+
+    // This check is expected to pass for the given input
+    storageHandler.checkTableSchemaType(description, table);
+  }
+
   private TableDescription getHashRangeTable() {
     TableDescription description = new TableDescription().withKeySchema(Arrays.asList(
             new KeySchemaElement().withAttributeName("hashKey"),


### PR DESCRIPTION
*Description of changes:*

Add option for serializing Hive null values (including those within collections) to DynamoDB null type if `"dynamodb.null.serialiation" = "true"` is specified.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
