### PR TITLE
Add support for projections for DynamoDB table scan spark jobs

### DIFF
--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBClient.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBClient.java
@@ -53,6 +53,8 @@ import com.amazonaws.services.dynamodbv2.model.TableDescription;
 import com.amazonaws.services.dynamodbv2.model.WriteRequest;
 import com.amazonaws.thirdparty.joda.time.Duration;
 
+import java.util.Collection;
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -145,7 +147,8 @@ public class DynamoDBClient {
   }
 
   public RetryResult<ScanResult> scanTable(
-      String tableName, DynamoDBQueryFilter dynamoDBQueryFilter, Integer segment, Integer
+      String tableName, final Collection<String> attributes,
+      DynamoDBQueryFilter dynamoDBQueryFilter, Integer segment, Integer
       totalSegments, Map<String, AttributeValue> exclusiveStartKey, long limit, Reporter reporter) {
     final ScanRequest scanRequest = new ScanRequest(tableName)
         .withExclusiveStartKey(exclusiveStartKey)
@@ -153,6 +156,11 @@ public class DynamoDBClient {
         .withSegment(segment)
         .withTotalSegments(totalSegments)
         .withReturnConsumedCapacity(ReturnConsumedCapacity.TOTAL);
+
+    if (!attributes.isEmpty()) {
+      final String projection = StringUtils.join(attributes.toArray(), ",");
+      scanRequest.setProjectionExpression(projection);
+    }
 
     if (dynamoDBQueryFilter != null) {
       Map<String, Condition> scanFilter = dynamoDBQueryFilter.getScanFilter();

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/preader/ScanRecordReadRequest.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/preader/ScanRecordReadRequest.java
@@ -37,7 +37,7 @@ public class ScanRecordReadRequest extends AbstractRecordReadRequest {
   @Override
   protected PageResults<Map<String, AttributeValue>> fetchPage(RequestLimit lim) {
     // Read from DynamoDB
-    RetryResult<ScanResult> retryResult = context.getClient().scanTable(tableName, null, segment,
+    RetryResult<ScanResult> retryResult = context.getClient().scanTable(tableName, context.getAttributes(),null, segment,
         context.getSplit().getTotalSegments(), lastEvaluatedKey, lim.items, context.getReporter());
 
     ScanResult result = retryResult.result;

--- a/emr-dynamodb-hadoop/src/test/java/org/apache/hadoop/dynamodb/preader/ScanRecordReadRequestTest.java
+++ b/emr-dynamodb-hadoop/src/test/java/org/apache/hadoop/dynamodb/preader/ScanRecordReadRequestTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.when;
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import com.amazonaws.services.dynamodbv2.model.ScanResult;
 
+import java.util.Set;
 import org.apache.hadoop.dynamodb.DynamoDBClient;
 import org.apache.hadoop.dynamodb.DynamoDBFibonacciRetryer.RetryResult;
 import org.apache.hadoop.dynamodb.filter.DynamoDBQueryFilter;
@@ -53,6 +54,7 @@ public final class ScanRecordReadRequestTest {
   private void stubScanTableWith(RetryResult<ScanResult> scanResultRetryResult) {
     when(client.scanTable(
         anyString(),
+        any(Set.class),
         any(DynamoDBQueryFilter.class),
         anyInt(),
         anyInt(),

--- a/emr-dynamodb-hadoop/src/test/java/org/apache/hadoop/dynamodb/read/DynamoDBRecordReaderTest.java
+++ b/emr-dynamodb-hadoop/src/test/java/org/apache/hadoop/dynamodb/read/DynamoDBRecordReaderTest.java
@@ -25,6 +25,7 @@ import com.amazonaws.services.dynamodbv2.model.ProvisionedThroughputDescription;
 import com.amazonaws.services.dynamodbv2.model.ScanResult;
 import com.amazonaws.services.dynamodbv2.model.TableDescription;
 
+import java.util.Collection;
 import org.apache.hadoop.dynamodb.DynamoDBClient;
 import org.apache.hadoop.dynamodb.DynamoDBConstants;
 import org.apache.hadoop.dynamodb.DynamoDBFibonacciRetryer.RetryResult;
@@ -70,7 +71,8 @@ public class DynamoDBRecordReaderTest {
       }
 
       @Override
-      public RetryResult<ScanResult> scanTable(String tableName, DynamoDBQueryFilter
+      public RetryResult<ScanResult> scanTable(String tableName,
+          final Collection<String> attributes, DynamoDBQueryFilter
           dynamoDBQueryFilter, Integer segment, Integer totalSegments, Map<String,
           AttributeValue> exclusiveStartKey, long limit, Reporter reporter) {
 
@@ -133,7 +135,8 @@ public class DynamoDBRecordReaderTest {
       }
 
       @Override
-      public RetryResult<ScanResult> scanTable(String tableName, DynamoDBQueryFilter
+      public RetryResult<ScanResult> scanTable(String tableName,
+          final Collection<String> attributes, DynamoDBQueryFilter
           dynamoDBQueryFilter, Integer segment, Integer totalSegments, Map<String,
           AttributeValue> exclusiveStartKey, long limit, Reporter reporter) {
         return new RetryResult<>(getHashNumberRangeKeyItems(HASH_KEYS, "S"), 0);
@@ -175,7 +178,8 @@ public class DynamoDBRecordReaderTest {
       }
 
       @Override
-      public RetryResult<ScanResult> scanTable(String tableName, DynamoDBQueryFilter
+      public RetryResult<ScanResult> scanTable(String tableName,
+          final Collection<String> attributes, DynamoDBQueryFilter
           dynamoDBQueryFilter, Integer segment, Integer totalSegments, Map<String,
           AttributeValue> exclusiveStartKey, long limit, Reporter reporter) {
         assertNull(exclusiveStartKey);
@@ -217,7 +221,8 @@ public class DynamoDBRecordReaderTest {
       }
 
       @Override
-      public RetryResult<ScanResult> scanTable(String tableName, DynamoDBQueryFilter
+      public RetryResult<ScanResult> scanTable(String tableName,
+          final Collection<String> attributes, DynamoDBQueryFilter
           dynamoDBQueryFilter, Integer segment, Integer totalSegments, Map<String,
           AttributeValue> exclusiveStartKey, long limit, Reporter reporter) {
         assertEquals(0, (int) segment);
@@ -256,7 +261,8 @@ public class DynamoDBRecordReaderTest {
       }
 
       @Override
-      public RetryResult<ScanResult> scanTable(String tableName, DynamoDBQueryFilter
+      public RetryResult<ScanResult> scanTable(String tableName,
+          final Collection<String> attributes, DynamoDBQueryFilter
           dynamoDBQueryFilter, Integer segment, Integer totalSegments, Map<String,
           AttributeValue> exclusiveStartKey, long limit, Reporter reporter) {
         throw new RuntimeException("Unrecoverable Exception");


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adding support to select only required fields while scanning DynamoDB table to reduce the amount of data transferred.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
