### PR TITLE
Add Hive 3.x support

### DIFF
--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBUtil.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBUtil.java
@@ -28,7 +28,7 @@ import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
 
 import com.amazonaws.regions.RegionUtils;
-import com.amazonaws.regions.ServiceAbbreviations;
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import com.amazonaws.services.dynamodbv2.model.TableDescription;
 import com.amazonaws.util.EC2MetadataUtils;
@@ -250,7 +250,7 @@ public final class DynamoDBUtil {
       if (Strings.isNullOrEmpty(region)) {
         region = DynamoDBConstants.DEFAULT_AWS_REGION;
       }
-      endpoint = RegionUtils.getRegion(region).getServiceEndpoint(ServiceAbbreviations.Dynamodb);
+      endpoint = RegionUtils.getRegion(region).getServiceEndpoint(AmazonDynamoDB.ENDPOINT_PREFIX);
     }
     log.info("Using endpoint for DynamoDB: " + endpoint);
     return endpoint;

--- a/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/DynamoDBStorageHandler.java
+++ b/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/DynamoDBStorageHandler.java
@@ -29,10 +29,10 @@ import org.apache.hadoop.hive.dynamodb.type.HiveDynamoDBTypeFactory;
 import org.apache.hadoop.hive.dynamodb.util.HiveDynamoDBUtil;
 import org.apache.hadoop.hive.dynamodb.write.HiveDynamoDBOutputFormat;
 import org.apache.hadoop.hive.metastore.HiveMetaHook;
-import org.apache.hadoop.hive.metastore.MetaStoreUtils;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.hadoop.hive.metastore.api.Table;
+import org.apache.hadoop.hive.metastore.TableType;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.metadata.HiveStorageHandler;
 import org.apache.hadoop.hive.ql.metadata.HiveStoragePredicateHandler;
@@ -74,7 +74,7 @@ public class DynamoDBStorageHandler
     DynamoDBClient client = createDynamoDBClient(table);
     try {
 
-      boolean isExternal = MetaStoreUtils.isExternalTable(table);
+      boolean isExternal = table.getTableType().equals(TableType.EXTERNAL_TABLE.toString());
 
       if (!isExternal) {
         throw new MetaException("Only EXTERNAL tables are supported for DynamoDB.");
@@ -210,6 +210,10 @@ public class DynamoDBStorageHandler
     } finally {
       client.close();
     }
+  }
+
+  @Override
+  public void configureInputJobCredentials(TableDesc tableDesc, Map<String, String> secrets) {
   }
 
   private void useExplicitThroughputIfRequired(Map<String, String> jobProperties, TableDesc tableDesc) {

--- a/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/type/HiveDynamoDBNullType.java
+++ b/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/type/HiveDynamoDBNullType.java
@@ -2,10 +2,8 @@ package org.apache.hadoop.hive.dynamodb.type;
 
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import org.apache.hadoop.dynamodb.type.DynamoDBNullType;
-import org.apache.hadoop.hive.dynamodb.util.DynamoDBDataParser;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
-import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
 
 public class HiveDynamoDBNullType extends DynamoDBNullType implements HiveDynamoDBType {
 

--- a/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/write/HiveDynamoDBOutputFormat.java
+++ b/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/write/HiveDynamoDBOutputFormat.java
@@ -21,7 +21,6 @@ import org.apache.hadoop.hive.ql.io.HiveOutputFormat;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.Writable;
 import org.apache.hadoop.mapred.JobConf;
-import org.apache.hadoop.mapred.OutputFormat;
 import org.apache.hadoop.util.Progressable;
 
 import java.io.IOException;

--- a/pom.xml
+++ b/pom.xml
@@ -21,9 +21,9 @@
         <aws-java-sdk.version>1.11.475</aws-java-sdk.version>
         <hadoop.version>2.7.3</hadoop.version>
         <hive1.version>1.0.0</hive1.version>
-        <hive1.2.version>1.2.1</hive1.2.version>
-        <hive2.version>2.3.0</hive2.version>
-        <hive3.version>3.1.0</hive3.version>
+        <hive1.2.version>1.2.2</hive1.2.version>
+        <hive2.version>2.3.7</hive2.version>
+        <hive3.version>3.1.2</hive3.version>
         <!-- Use the more recent version as it will be more likely to
         have all the interfaces/classes we need for shims to work -->
         <hive.version>${hive3.version}</hive.version>

--- a/pom.xml
+++ b/pom.xml
@@ -23,9 +23,10 @@
         <hive1.version>1.0.0</hive1.version>
         <hive1.2.version>1.2.1</hive1.2.version>
         <hive2.version>2.3.0</hive2.version>
+        <hive3.version>3.1.0</hive3.version>
         <!-- Use the more recent version as it will be more likely to
         have all the interfaces/classes we need for shims to work -->
-        <hive.version>${hive2.version}</hive.version>
+        <hive.version>${hive3.version}</hive.version>
         <git.commit.id.plugin.version>2.2.4</git.commit.id.plugin.version>
         <gson.version>2.1</gson.version>
         <guava.version>19.0</guava.version>

--- a/shims/hive3-shims/pom.xml
+++ b/shims/hive3-shims/pom.xml
@@ -1,0 +1,31 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                      http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>com.amazon.emr</groupId>
+        <artifactId>shims</artifactId>
+        <version>4.15.0-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>hive3-shims</artifactId>
+    <packaging>jar</packaging>
+
+    <name>Hive3Shims</name>
+    <description>Shims for Hive-3.x compatibility</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.hive</groupId>
+            <artifactId>hive-exec</artifactId>
+            <version>${hive3.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.amazon.emr</groupId>
+            <artifactId>shims-common</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/shims/hive3-shims/src/main/java/org/apache/hadoop/hive/dynamodb/shims/DynamoDbHive3Shims.java
+++ b/shims/hive3-shims/src/main/java/org/apache/hadoop/hive/dynamodb/shims/DynamoDbHive3Shims.java
@@ -24,7 +24,7 @@ import java.util.Properties;
 
 final class DynamoDbHive3Shims implements DynamoDbHiveShims {
 
-  private static final String HIVE_3_VERSION = "3.1.0";
+  private static final String HIVE_3_VERSION = "3.1";
 
   static boolean supportsVersion(String version) {
     return version.startsWith(HIVE_3_VERSION);

--- a/shims/hive3-shims/src/main/java/org/apache/hadoop/hive/dynamodb/shims/DynamoDbHive3Shims.java
+++ b/shims/hive3-shims/src/main/java/org/apache/hadoop/hive/dynamodb/shims/DynamoDbHive3Shims.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+ * except in compliance with the License. A copy of the License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "LICENSE.TXT" file accompanying this file. This file is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under the License.
+ */
+
+package org.apache.hadoop.hive.dynamodb.shims;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.ql.exec.SerializationUtilities;
+import org.apache.hadoop.hive.ql.index.IndexSearchCondition;
+import org.apache.hadoop.hive.ql.plan.ExprNodeDesc;
+import org.apache.hadoop.hive.ql.plan.ExprNodeGenericFuncDesc;
+import org.apache.hadoop.hive.serde2.SerDeException;
+
+import java.util.Properties;
+
+final class DynamoDbHive3Shims implements DynamoDbHiveShims {
+
+  private static final String HIVE_3_VERSION = "3.1.0";
+
+  static boolean supportsVersion(String version) {
+    return version.startsWith(HIVE_3_VERSION);
+  }
+
+  @Override
+  public ExprNodeDesc deserializeExpression(String serializedFilterExpr) {
+    return SerializationUtilities.deserializeExpression(serializedFilterExpr);
+  }
+
+  @Override
+  public ExprNodeGenericFuncDesc getIndexExpression(IndexSearchCondition condition) {
+    return condition.getIndexExpr();
+  }
+
+  /**
+   * Hive 1.2 and Hive 2.x share SerDeParameters implementations, so we can delegate to that shim.
+   */
+  @Override
+  public SerDeParametersShim getSerDeParametersShim(Configuration configuration,
+      Properties properties, String serDeName) throws SerDeException {
+    return new Hive3SerDeParametersShim(configuration, properties, serDeName);
+  }
+
+}
+

--- a/shims/hive3-shims/src/main/java/org/apache/hadoop/hive/dynamodb/shims/Hive3SerDeParametersShim.java
+++ b/shims/hive3-shims/src/main/java/org/apache/hadoop/hive/dynamodb/shims/Hive3SerDeParametersShim.java
@@ -1,0 +1,34 @@
+package org.apache.hadoop.hive.dynamodb.shims;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.serde2.SerDeException;
+import org.apache.hadoop.hive.serde2.lazy.LazySerDeParameters;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
+
+import java.util.List;
+import java.util.Properties;
+
+class Hive3SerDeParametersShim implements SerDeParametersShim {
+
+  private final LazySerDeParameters realSerDeParameters;
+
+  Hive3SerDeParametersShim(Configuration configuration, Properties properties, String serDeName)
+      throws SerDeException {
+    this.realSerDeParameters = new LazySerDeParameters(configuration, properties, serDeName);
+  }
+
+  @Override
+  public List<String> getColumnNames() {
+    return this.realSerDeParameters.getColumnNames();
+  }
+
+  @Override
+  public List<TypeInfo> getColumnTypes() {
+    return this.realSerDeParameters.getColumnTypes();
+  }
+
+  @Override
+  public byte[] getSeparators() {
+    return this.realSerDeParameters.getSeparators();
+  }
+}

--- a/shims/loader/pom.xml
+++ b/shims/loader/pom.xml
@@ -34,6 +34,11 @@
         </dependency>
         <dependency>
             <groupId>com.amazon.emr</groupId>
+            <artifactId>hive3-shims</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.amazon.emr</groupId>
             <artifactId>shims-common</artifactId>
             <version>${project.parent.version}</version>
         </dependency>

--- a/shims/loader/pom.xml
+++ b/shims/loader/pom.xml
@@ -39,11 +39,6 @@
         </dependency>
         <dependency>
             <groupId>com.amazon.emr</groupId>
-            <artifactId>hive1-shims</artifactId>
-            <version>${project.parent.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.amazon.emr</groupId>
             <artifactId>hive1.2-shims</artifactId>
             <version>${project.parent.version}</version>
         </dependency>

--- a/shims/loader/src/main/java/org/apache/hadoop/hive/dynamodb/shims/ShimsLoader.java
+++ b/shims/loader/src/main/java/org/apache/hadoop/hive/dynamodb/shims/ShimsLoader.java
@@ -54,6 +54,12 @@ public final class ShimsLoader {
       } catch (InstantiationException | IllegalAccessException e) {
         throw new RuntimeException("unable to get instance of Hive 2.x shim class");
       }
+    } else if (DynamoDbHive3Shims.supportsVersion(hiveVersion)) {
+      try {
+        return DynamoDbHive3Shims.class.newInstance();
+      } catch (InstantiationException | IllegalAccessException e) {
+        throw new RuntimeException("unable to get instance of Hive 3.x shim class");
+      }
     } else {
       throw new RuntimeException("Shim class for Hive version " + hiveVersion + " does not exist");
     }

--- a/shims/pom.xml
+++ b/shims/pom.xml
@@ -20,6 +20,7 @@
         <module>hive1-shims</module>
         <module>hive1.2-shims</module>
         <module>hive2-shims</module>
+        <module>hive3-shims</module>
         <module>loader</module>
     </modules>
 


### PR DESCRIPTION
Adds Hive 3.x support.

Tested on Hortonworks 3.0.1 with Hive 3.1

--

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
