### PR TITLE
Upgrade Java version to 1.8 & upgrade Guava version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         </license>
     </licenses>
     <properties>
-        <java.version>1.7</java.version>
+        <java.version>1.8</java.version>
         <aws-java-sdk.version>1.11.475</aws-java-sdk.version>
         <hadoop.version>2.7.3</hadoop.version>
         <hive1.version>1.0.0</hive1.version>
@@ -28,7 +28,7 @@
         <hive.version>${hive2.version}</hive.version>
         <git.commit.id.plugin.version>2.2.4</git.commit.id.plugin.version>
         <gson.version>2.1</gson.version>
-        <guava.version>19.0</guava.version>
+        <guava.version>24.1.1-jre</guava.version>
         <jackson-databind.version>2.6.7.2</jackson-databind.version>
         <joda-time.version>2.8.1</joda-time.version>
         <junit.version>4.12</junit.version>


### PR DESCRIPTION
Upgrade Java version to 1.8 & upgrade Guava version due to the security issue of Guava

*Description of changes:

According to the github security alert, we need to upgrade ```com.google.guava:guava``` to version 24.1.1 or later.

Github Dependabot shows that Dependabot cannot update to the required version so we need to manually update Guava version.

Since ```guava 24.1.1``` depends on ```Java 1.8```, I also upgraded Java from 1.7 to 1.8 at the same time.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
