### PR TITLE
Add GSI/LSI pushdown support for Hive

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,15 @@ TBLPROPERTIES (
 
 `dynamodb.type.mapping` and `dynamodb.null.serialization` are optional parameters.
 
+Hive query will automatically choose the most suitable secondary index if there is any based on the
+search condition. For an index that can be chosen, it should have following properties:
+1. It has all its index keys in Hive query search condition;
+2. It contains all the DynamoDB attributes mentioned in `dynamodb.column.mapping`. (If you have to
+map more columns than index attributes in your Hive table but still want to use an index when
+running queries that only select the attributes within that index, consider create another
+Hive table and narrow down the mappings to only include the index attributes. Use that table for
+reading the index attributes to reduce table scans)
+
 ## Example: Input/Output Formats with Spark
 Using the DynamoDBInputFormat and DynamoDBOutputFormat classes with `spark-shell`:
 ```

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBClient.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBClient.java
@@ -63,6 +63,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.dynamodb.DynamoDBFibonacciRetryer.RetryResult;
+import org.apache.hadoop.dynamodb.filter.DynamoDBIndexInfo;
 import org.apache.hadoop.dynamodb.filter.DynamoDBQueryFilter;
 import org.apache.hadoop.mapred.Reporter;
 import org.apache.hadoop.util.ReflectionUtils;
@@ -178,6 +179,12 @@ public class DynamoDBClient {
         .withKeyConditions(dynamoDBQueryFilter.getKeyConditions())
         .withLimit(Ints.checkedCast(limit))
         .withReturnConsumedCapacity(ReturnConsumedCapacity.TOTAL);
+
+    DynamoDBIndexInfo index = dynamoDBQueryFilter.getIndex();
+    if (index != null) {
+      log.debug("Using DynamoDB index: " + index.getIndexName());
+      queryRequest.setIndexName(index.getIndexName());
+    }
 
     RetryResult<QueryResult> retryResult = getRetryDriver().runWithRetry(
         new Callable<QueryResult>() {

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/filter/DynamoDBIndexInfo.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/filter/DynamoDBIndexInfo.java
@@ -1,0 +1,46 @@
+package org.apache.hadoop.dynamodb.filter;
+
+import com.amazonaws.services.dynamodbv2.model.KeySchemaElement;
+import com.amazonaws.services.dynamodbv2.model.Projection;
+import java.util.List;
+
+public class DynamoDBIndexInfo {
+
+  private String indexName;
+
+  private List<KeySchemaElement> indexSchema;
+  private Projection indexProjection;
+
+  public DynamoDBIndexInfo(String indexName,
+      List<KeySchemaElement> indexSchema,
+      Projection indexProjection) {
+    this.indexName = indexName;
+    this.indexSchema = indexSchema;
+    this.indexProjection = indexProjection;
+  }
+
+  public String getIndexName() {
+    return indexName;
+  }
+
+  public void setIndexName(String indexName) {
+    this.indexName = indexName;
+  }
+
+  public List<KeySchemaElement> getIndexSchema() {
+    return indexSchema;
+  }
+
+  public void setIndexSchema(
+      List<KeySchemaElement> indexSchema) {
+    this.indexSchema = indexSchema;
+  }
+
+  public Projection getIndexProjection() {
+    return indexProjection;
+  }
+
+  public void setIndexProjection(Projection indexProjection) {
+    this.indexProjection = indexProjection;
+  }
+}

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/filter/DynamoDBQueryFilter.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/filter/DynamoDBQueryFilter.java
@@ -22,6 +22,16 @@ public class DynamoDBQueryFilter {
   private final Map<String, Condition> keyConditions = new HashMap<>();
   private final Map<String, Condition> scanFilter = new HashMap<>();
 
+  private DynamoDBIndexInfo index;
+
+  public DynamoDBIndexInfo getIndex() {
+    return index;
+  }
+
+  public void setIndex(DynamoDBIndexInfo index) {
+    this.index = index;
+  }
+
   public Map<String, Condition> getKeyConditions() {
     return keyConditions;
   }

--- a/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/read/HiveDynamoDBInputFormat.java
+++ b/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/read/HiveDynamoDBInputFormat.java
@@ -13,7 +13,7 @@
 
 package org.apache.hadoop.hive.dynamodb.read;
 
-import com.amazonaws.services.dynamodbv2.model.KeySchemaElement;
+import com.amazonaws.services.dynamodbv2.model.TableDescription;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
@@ -149,10 +149,13 @@ public class HiveDynamoDBInputFormat extends DynamoDBInputFormat {
         ShimsLoader.getHiveShims().deserializeExpression(filterExprSerialized);
 
     DynamoDBFilterPushdown pushdown = new DynamoDBFilterPushdown();
-    List<KeySchemaElement> schema =
-        client.describeTable(conf.get(DynamoDBConstants.TABLE_NAME)).getKeySchema();
+    TableDescription tableDescription =
+        client.describeTable(conf.get(DynamoDBConstants.TABLE_NAME));
     DynamoDBQueryFilter queryFilter = pushdown.predicateToDynamoDBFilter(
-        schema, hiveDynamoDBMapping, hiveTypeMapping, filterExpr);
+        tableDescription.getKeySchema(),
+        tableDescription.getLocalSecondaryIndexes(),
+        tableDescription.getGlobalSecondaryIndexes(),
+        hiveDynamoDBMapping, hiveTypeMapping, filterExpr);
     return queryFilter;
   }
 

--- a/emr-dynamodb-hive/src/test/java/org/apache/hadoop/hive/dynamodb/filter/DynamoDBFilterPushdownTest.java
+++ b/emr-dynamodb-hive/src/test/java/org/apache/hadoop/hive/dynamodb/filter/DynamoDBFilterPushdownTest.java
@@ -1,0 +1,511 @@
+package org.apache.hadoop.hive.dynamodb.filter;
+
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import com.amazonaws.services.dynamodbv2.model.Condition;
+import com.amazonaws.services.dynamodbv2.model.GlobalSecondaryIndexDescription;
+import com.amazonaws.services.dynamodbv2.model.KeySchemaElement;
+import com.amazonaws.services.dynamodbv2.model.LocalSecondaryIndexDescription;
+import com.amazonaws.services.dynamodbv2.model.Projection;
+import com.amazonaws.services.dynamodbv2.model.ProjectionType;
+import com.google.common.collect.Lists;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.hadoop.dynamodb.filter.DynamoDBFilterOperator;
+import org.apache.hadoop.dynamodb.filter.DynamoDBQueryFilter;
+import org.apache.hadoop.hive.ql.exec.FunctionRegistry;
+import org.apache.hadoop.hive.ql.metadata.HiveStoragePredicateHandler.DecomposedPredicate;
+import org.apache.hadoop.hive.ql.plan.ExprNodeColumnDesc;
+import org.apache.hadoop.hive.ql.plan.ExprNodeConstantDesc;
+import org.apache.hadoop.hive.ql.plan.ExprNodeDesc;
+import org.apache.hadoop.hive.ql.plan.ExprNodeGenericFuncDesc;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFOPEqual;
+import org.apache.hadoop.hive.serde.serdeConstants;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class DynamoDBFilterPushdownTest {
+
+  private DynamoDBFilterPushdown dynamoDBFilterPushdown;
+
+  private static final String HASH_KEY_NAME = "hashKey";
+  private static final String HASH_KEY_TYPE = "HASH";
+  private static final String HASH_KEY_VALUE = "1";
+  private static final String RANGE_KEY_NAME = "rangeKey";
+  private static final String RANGE_KEY_TYPE = "RANGE";
+  private static final String RANGE_KEY_VALUE = "2";
+  private static final String COLUMN1_NAME = "column1";
+  private static final String COLUMN1_VALUE = "3";
+  private static final String COLUMN2_NAME = "column2";
+  private static final String COLUMN2_VALUE = "4";
+  private static final String COLUMN3_NAME = "column3";
+  private static final String COLUMN4_NAME = "column4";
+  private static final String LOCAL_SECONDARY_INDEX_NAME = "LSI";
+  private static final String GLOBAL_SECONDARY_INDEX_NAME = "GSI";
+
+  private final ExprNodeDesc hashKeyPredicate = new ExprNodeGenericFuncDesc(
+      TypeInfoFactory.booleanTypeInfo,
+      new GenericUDFOPEqual(), Lists.newArrayList(
+      new ExprNodeColumnDesc(TypeInfoFactory.stringTypeInfo, HASH_KEY_NAME, null, false),
+      new ExprNodeConstantDesc(TypeInfoFactory.longTypeInfo, HASH_KEY_VALUE)
+  ));
+  private final ExprNodeDesc rangeKeyPredicate = new ExprNodeGenericFuncDesc(
+      TypeInfoFactory.booleanTypeInfo,
+      new GenericUDFOPEqual(), Lists.newArrayList(
+      new ExprNodeColumnDesc(TypeInfoFactory.stringTypeInfo, RANGE_KEY_NAME, null, false),
+      new ExprNodeConstantDesc(TypeInfoFactory.stringTypeInfo, RANGE_KEY_VALUE)
+  ));
+  private final ExprNodeDesc column1Predicate = new ExprNodeGenericFuncDesc(
+      TypeInfoFactory.booleanTypeInfo,
+      new GenericUDFOPEqual(), Lists.newArrayList(
+      new ExprNodeColumnDesc(TypeInfoFactory.stringTypeInfo, COLUMN1_NAME, null, false),
+      new ExprNodeConstantDesc(TypeInfoFactory.longTypeInfo, COLUMN1_VALUE)
+  ));
+  private final ExprNodeDesc column2Predicate = new ExprNodeGenericFuncDesc(
+      TypeInfoFactory.booleanTypeInfo,
+      new GenericUDFOPEqual(), Lists.newArrayList(
+      new ExprNodeColumnDesc(TypeInfoFactory.stringTypeInfo, COLUMN2_NAME, null, false),
+      new ExprNodeConstantDesc(TypeInfoFactory.longTypeInfo, COLUMN2_VALUE)
+  ));
+
+  private final List<KeySchemaElement> tableKeySchema =
+      createKeySchema(HASH_KEY_NAME, RANGE_KEY_NAME);
+  private final Map<String, String> hiveDynamoDBMapping = initHiveDynamoDBMapping();
+  private final Map<String, String> hiveTypeMapping = initHiveTypeMapping();
+
+  @Before
+  public void setup() {
+    dynamoDBFilterPushdown = new DynamoDBFilterPushdown();
+  }
+
+  @Test
+  public void testPushPredicate() {
+    assertPushablePredicate(serdeConstants.DOUBLE_TYPE_NAME,
+        new ExprNodeConstantDesc(TypeInfoFactory.doubleTypeInfo, 1.0));
+    assertPushablePredicate(serdeConstants.BIGINT_TYPE_NAME,
+        new ExprNodeConstantDesc(TypeInfoFactory.longTypeInfo, 1));
+    assertPushablePredicate(serdeConstants.STRING_TYPE_NAME,
+        new ExprNodeConstantDesc(TypeInfoFactory.stringTypeInfo, "1"));
+    assertPushablePredicate(serdeConstants.BINARY_TYPE_NAME,
+        new ExprNodeConstantDesc(TypeInfoFactory.binaryTypeInfo, new byte[]{1}));
+
+    assertUnpushablePredicate(serdeConstants.BOOLEAN_TYPE_NAME,
+        new ExprNodeConstantDesc(TypeInfoFactory.booleanTypeInfo, true));
+    assertUnpushablePredicate(serdeConstants.LIST_TYPE_NAME,
+        new ExprNodeConstantDesc(TypeInfoFactory.getListTypeInfo(TypeInfoFactory.longTypeInfo),
+            Lists.newArrayList(1)));
+  }
+
+  private void assertPushablePredicate(String hiveType, ExprNodeDesc constantDesc) {
+    Map<String, String> hiveTypeMapping = new HashMap<>();
+    hiveTypeMapping.put("column", hiveType);
+
+    ExprNodeDesc predicate = new ExprNodeGenericFuncDesc(TypeInfoFactory.booleanTypeInfo,
+        new GenericUDFOPEqual(), Lists.newArrayList(
+        new ExprNodeColumnDesc(TypeInfoFactory.stringTypeInfo, "column", null, false),
+        constantDesc
+    ));
+
+    DecomposedPredicate decomposedPredicate =
+        dynamoDBFilterPushdown.pushPredicate(hiveTypeMapping, predicate);
+    Assert.assertEquals(decomposedPredicate.pushedPredicate.toString(),
+        predicate.toString());
+  }
+
+  private void assertUnpushablePredicate(String hiveType, ExprNodeDesc constantDesc) {
+    Map<String, String> hiveTypeMapping = new HashMap<>();
+    hiveTypeMapping.put("column", hiveType);
+
+    ExprNodeDesc predicate = new ExprNodeGenericFuncDesc(TypeInfoFactory.booleanTypeInfo,
+        new GenericUDFOPEqual(), Lists.newArrayList(
+        new ExprNodeColumnDesc(TypeInfoFactory.stringTypeInfo, "column", null, false),
+        constantDesc
+    ));
+
+    DecomposedPredicate decomposedPredicate =
+        dynamoDBFilterPushdown.pushPredicate(hiveTypeMapping, predicate);
+    Assert.assertNull(decomposedPredicate);
+  }
+
+  @Test
+  public void testPushPredicateDoubleTypeNotInHiveTypeMappingNotPushed() {
+    Map<String, String> hiveTypeMapping = new HashMap<>();
+
+    ExprNodeDesc predicate = new ExprNodeGenericFuncDesc(TypeInfoFactory.booleanTypeInfo,
+        new GenericUDFOPEqual(), Lists.newArrayList(
+        new ExprNodeColumnDesc(TypeInfoFactory.stringTypeInfo, "column", null, false),
+        new ExprNodeConstantDesc(TypeInfoFactory.doubleTypeInfo, 1.0)
+    ));
+
+    DecomposedPredicate decomposedPredicate =
+        dynamoDBFilterPushdown.pushPredicate(hiveTypeMapping, predicate);
+    Assert.assertNull(decomposedPredicate);
+  }
+
+  @Test
+  public void testPredicateToDynamoDBFilterWithNoIndexesAndNoHashKey() {
+    ExprNodeDesc combinedPredicate = buildPredicate(Lists.newArrayList(
+        rangeKeyPredicate,
+        column2Predicate));
+
+    DynamoDBQueryFilter dynamoDBQueryFilter = dynamoDBFilterPushdown.predicateToDynamoDBFilter(
+        tableKeySchema, null, null,
+        hiveDynamoDBMapping, hiveTypeMapping, combinedPredicate);
+
+    Assert.assertNull(dynamoDBQueryFilter.getIndex());
+    Assert.assertEquals(0, dynamoDBQueryFilter.getKeyConditions().size());
+  }
+
+  @Test
+  public void testPredicateToDynamoDBFilterWithNoIndexesAndTableOnlyHasHashKey() {
+    ExprNodeDesc combinedPredicate = buildPredicate(Lists.newArrayList(
+        hashKeyPredicate,
+        column1Predicate));
+
+    DynamoDBQueryFilter dynamoDBQueryFilter = dynamoDBFilterPushdown.predicateToDynamoDBFilter(
+        tableKeySchema, null, null,
+        hiveDynamoDBMapping, hiveTypeMapping, combinedPredicate);
+
+    Assert.assertNull(dynamoDBQueryFilter.getIndex());
+    Assert.assertEquals(1, dynamoDBQueryFilter.getKeyConditions().size());
+    assertKeyCondition(HASH_KEY_NAME, HASH_KEY_VALUE, dynamoDBQueryFilter);
+  }
+
+  @Test
+  public void testPredicateToDynamoDBFilterWithHashKeyAndRangeKey() {
+    ExprNodeDesc combinedPredicate = buildPredicate(Lists.newArrayList(
+        hashKeyPredicate,
+        rangeKeyPredicate,
+        column1Predicate,
+        column2Predicate));
+
+    GlobalSecondaryIndexDescription gsi = createGSI(GLOBAL_SECONDARY_INDEX_NAME,
+        COLUMN1_NAME, COLUMN2_NAME, ProjectionType.ALL.toString(), null);
+
+    DynamoDBQueryFilter dynamoDBQueryFilter = dynamoDBFilterPushdown.predicateToDynamoDBFilter(
+        tableKeySchema, null, Lists.newArrayList(gsi),
+        hiveDynamoDBMapping, hiveTypeMapping, combinedPredicate);
+
+    Assert.assertNull(dynamoDBQueryFilter.getIndex());
+    Assert.assertEquals(2, dynamoDBQueryFilter.getKeyConditions().size());
+    assertKeyCondition(HASH_KEY_NAME, HASH_KEY_VALUE, dynamoDBQueryFilter);
+    assertKeyCondition(RANGE_KEY_NAME, RANGE_KEY_VALUE, dynamoDBQueryFilter);
+  }
+
+  @Test
+  public void testPredicateToDynamoDBFilterWithLSIAllProjection() {
+    ExprNodeDesc combinedPredicate = buildPredicate(Lists.newArrayList(
+        hashKeyPredicate,
+        column1Predicate,
+        column2Predicate));
+
+    LocalSecondaryIndexDescription lsi = createLSI(LOCAL_SECONDARY_INDEX_NAME,
+        HASH_KEY_NAME, COLUMN1_NAME, ProjectionType.ALL.toString(), null);
+
+    DynamoDBQueryFilter dynamoDBQueryFilter = dynamoDBFilterPushdown.predicateToDynamoDBFilter(
+        tableKeySchema, Lists.newArrayList(lsi), null,
+        hiveDynamoDBMapping, hiveTypeMapping, combinedPredicate);
+
+    Assert.assertEquals(LOCAL_SECONDARY_INDEX_NAME, dynamoDBQueryFilter.getIndex().getIndexName());
+    Assert.assertEquals(2, dynamoDBQueryFilter.getKeyConditions().size());
+    assertKeyCondition(HASH_KEY_NAME, HASH_KEY_VALUE, dynamoDBQueryFilter);
+    assertKeyCondition(COLUMN1_NAME, COLUMN1_VALUE, dynamoDBQueryFilter);
+  }
+
+  @Test
+  public void testPredicateToDynamoDBFilterWithLSIKeysOnlyProjection() {
+    ExprNodeDesc combinedPredicate = buildPredicate(Lists.newArrayList(
+        hashKeyPredicate,
+        column1Predicate,
+        column2Predicate));
+
+    LocalSecondaryIndexDescription lsi = createLSI(LOCAL_SECONDARY_INDEX_NAME,
+        HASH_KEY_NAME, COLUMN1_NAME, ProjectionType.KEYS_ONLY.toString(), null);
+
+    DynamoDBQueryFilter dynamoDBQueryFilter = dynamoDBFilterPushdown.predicateToDynamoDBFilter(
+        tableKeySchema, Lists.newArrayList(lsi), null,
+        hiveDynamoDBMapping, hiveTypeMapping, combinedPredicate);
+
+    Assert.assertNull(dynamoDBQueryFilter.getIndex());
+    Assert.assertEquals(1, dynamoDBQueryFilter.getKeyConditions().size());
+  }
+
+  @Test
+  public void testPredicateToDynamoDBFilterWithLSIIncludeProjectionNotContainAllMapping() {
+    ExprNodeDesc combinedPredicate = buildPredicate(Lists.newArrayList(
+        hashKeyPredicate,
+        column1Predicate,
+        column2Predicate));
+
+    LocalSecondaryIndexDescription lsi = createLSI(LOCAL_SECONDARY_INDEX_NAME,
+        HASH_KEY_NAME, COLUMN1_NAME, ProjectionType.INCLUDE.toString(),
+        Lists.newArrayList(COLUMN2_NAME));
+
+    DynamoDBQueryFilter dynamoDBQueryFilter = dynamoDBFilterPushdown.predicateToDynamoDBFilter(
+        tableKeySchema, Lists.newArrayList(lsi), null,
+        hiveDynamoDBMapping, hiveTypeMapping, combinedPredicate);
+
+    Assert.assertNull(dynamoDBQueryFilter.getIndex());
+    Assert.assertEquals(1, dynamoDBQueryFilter.getKeyConditions().size());
+  }
+
+  @Test
+  public void testPredicateToDynamoDBFilterWithLSIIncludeProjectionContainAllMapping() {
+    ExprNodeDesc combinedPredicate = buildPredicate(Lists.newArrayList(
+        hashKeyPredicate,
+        column1Predicate,
+        column2Predicate));
+
+    LocalSecondaryIndexDescription lsi = createLSI(LOCAL_SECONDARY_INDEX_NAME,
+        HASH_KEY_NAME, COLUMN1_NAME, ProjectionType.INCLUDE.toString(),
+        Lists.newArrayList(COLUMN2_NAME, COLUMN3_NAME, COLUMN4_NAME));
+
+    DynamoDBQueryFilter dynamoDBQueryFilter = dynamoDBFilterPushdown.predicateToDynamoDBFilter(
+        tableKeySchema, Lists.newArrayList(lsi), null,
+        hiveDynamoDBMapping, hiveTypeMapping, combinedPredicate);
+
+    Assert.assertEquals(LOCAL_SECONDARY_INDEX_NAME, dynamoDBQueryFilter.getIndex().getIndexName());
+    Assert.assertEquals(2, dynamoDBQueryFilter.getKeyConditions().size());
+    assertKeyCondition(HASH_KEY_NAME, HASH_KEY_VALUE, dynamoDBQueryFilter);
+    assertKeyCondition(COLUMN1_NAME, COLUMN1_VALUE, dynamoDBQueryFilter);
+  }
+
+  @Test
+  public void testPredicateToDynamoDBFilterWithHashKeyAndMismatchLSI() {
+    ExprNodeDesc combinedPredicate = buildPredicate(Lists.newArrayList(
+        hashKeyPredicate,
+        column2Predicate));
+
+    LocalSecondaryIndexDescription lsi = createLSI(LOCAL_SECONDARY_INDEX_NAME,
+        HASH_KEY_NAME, COLUMN1_NAME, ProjectionType.ALL.toString(), null);
+
+    DynamoDBQueryFilter dynamoDBQueryFilter = dynamoDBFilterPushdown.predicateToDynamoDBFilter(
+        tableKeySchema, Lists.newArrayList(lsi), null,
+        hiveDynamoDBMapping, hiveTypeMapping, combinedPredicate);
+
+    Assert.assertNull(dynamoDBQueryFilter.getIndex());
+    Assert.assertEquals(1, dynamoDBQueryFilter.getKeyConditions().size());
+    assertKeyCondition(HASH_KEY_NAME, HASH_KEY_VALUE, dynamoDBQueryFilter);
+  }
+
+  @Test
+  public void testPredicateToDynamoDBFilterWithGSIAllProjection() {
+    ExprNodeDesc combinedPredicate = buildPredicate(Lists.newArrayList(
+        rangeKeyPredicate,
+        column1Predicate,
+        column2Predicate));
+
+    GlobalSecondaryIndexDescription gsi = createGSI(GLOBAL_SECONDARY_INDEX_NAME,
+        COLUMN1_NAME, COLUMN2_NAME, ProjectionType.ALL.toString(), null);
+
+    DynamoDBQueryFilter dynamoDBQueryFilter = dynamoDBFilterPushdown.predicateToDynamoDBFilter(
+        tableKeySchema, null, Lists.newArrayList(gsi),
+        hiveDynamoDBMapping, hiveTypeMapping, combinedPredicate);
+
+    Assert.assertEquals(GLOBAL_SECONDARY_INDEX_NAME, dynamoDBQueryFilter.getIndex().getIndexName());
+    Assert.assertEquals(2, dynamoDBQueryFilter.getKeyConditions().size());
+    assertKeyCondition(COLUMN1_NAME, COLUMN1_VALUE, dynamoDBQueryFilter);
+    assertKeyCondition(COLUMN2_NAME, COLUMN2_VALUE, dynamoDBQueryFilter);
+  }
+
+  @Test
+  public void testPredicateToDynamoDBFilterWithGSIKeysOnlyProjection() {
+    ExprNodeDesc combinedPredicate = buildPredicate(Lists.newArrayList(
+        rangeKeyPredicate,
+        column1Predicate,
+        column2Predicate));
+
+    GlobalSecondaryIndexDescription gsi = createGSI(GLOBAL_SECONDARY_INDEX_NAME,
+        COLUMN1_NAME, COLUMN2_NAME, ProjectionType.KEYS_ONLY.toString(), null);
+
+    DynamoDBQueryFilter dynamoDBQueryFilter = dynamoDBFilterPushdown.predicateToDynamoDBFilter(
+        tableKeySchema, null, Lists.newArrayList(gsi),
+        hiveDynamoDBMapping, hiveTypeMapping, combinedPredicate);
+
+    Assert.assertNull(dynamoDBQueryFilter.getIndex());
+    Assert.assertEquals(0, dynamoDBQueryFilter.getKeyConditions().size());
+  }
+
+  @Test
+  public void testPredicateToDynamoDBFilterWithGSIIncludeProjectionNotContainAllMapping() {
+    ExprNodeDesc combinedPredicate = buildPredicate(Lists.newArrayList(
+        rangeKeyPredicate,
+        column1Predicate,
+        column2Predicate));
+
+    GlobalSecondaryIndexDescription gsi = createGSI(GLOBAL_SECONDARY_INDEX_NAME,
+        COLUMN1_NAME, COLUMN2_NAME, ProjectionType.INCLUDE.toString(),
+        Lists.newArrayList(COLUMN3_NAME));
+
+    DynamoDBQueryFilter dynamoDBQueryFilter = dynamoDBFilterPushdown.predicateToDynamoDBFilter(
+        tableKeySchema, null, Lists.newArrayList(gsi),
+        hiveDynamoDBMapping, hiveTypeMapping, combinedPredicate);
+
+    Assert.assertNull(dynamoDBQueryFilter.getIndex());
+    Assert.assertEquals(0, dynamoDBQueryFilter.getKeyConditions().size());
+  }
+
+  @Test
+  public void testPredicateToDynamoDBFilterWithGSIIncludeProjectionContainAllMapping() {
+    ExprNodeDesc combinedPredicate = buildPredicate(Lists.newArrayList(
+        rangeKeyPredicate,
+        column1Predicate,
+        column2Predicate));
+
+    GlobalSecondaryIndexDescription gsi = createGSI(GLOBAL_SECONDARY_INDEX_NAME,
+        COLUMN1_NAME, COLUMN2_NAME, ProjectionType.INCLUDE.toString(),
+        Lists.newArrayList(COLUMN3_NAME, COLUMN4_NAME));
+
+    DynamoDBQueryFilter dynamoDBQueryFilter = dynamoDBFilterPushdown.predicateToDynamoDBFilter(
+        tableKeySchema, null, Lists.newArrayList(gsi),
+        hiveDynamoDBMapping, hiveTypeMapping, combinedPredicate);
+
+    Assert.assertEquals(GLOBAL_SECONDARY_INDEX_NAME, dynamoDBQueryFilter.getIndex().getIndexName());
+    Assert.assertEquals(2, dynamoDBQueryFilter.getKeyConditions().size());
+    assertKeyCondition(COLUMN1_NAME, COLUMN1_VALUE, dynamoDBQueryFilter);
+    assertKeyCondition(COLUMN2_NAME, COLUMN2_VALUE, dynamoDBQueryFilter);
+  }
+
+  @Test
+  public void testPredicateToDynamoDBFilterWithMultipleGSIsHavingTheSameHashKey() {
+    ExprNodeDesc combinedPredicate = buildPredicate(Lists.newArrayList(
+        rangeKeyPredicate,
+        column1Predicate));
+
+    GlobalSecondaryIndexDescription gsi1 = createGSI(GLOBAL_SECONDARY_INDEX_NAME + "1",
+        COLUMN1_NAME, COLUMN2_NAME, ProjectionType.ALL.toString(), null);
+    GlobalSecondaryIndexDescription gsi2 = createGSI(GLOBAL_SECONDARY_INDEX_NAME + "2",
+        COLUMN1_NAME, RANGE_KEY_NAME, ProjectionType.ALL.toString(), null);
+
+    DynamoDBQueryFilter dynamoDBQueryFilter = dynamoDBFilterPushdown.predicateToDynamoDBFilter(
+        tableKeySchema, null, Lists.newArrayList(gsi1, gsi2),
+        hiveDynamoDBMapping, hiveTypeMapping, combinedPredicate);
+
+    Assert.assertEquals(GLOBAL_SECONDARY_INDEX_NAME + "2",
+        dynamoDBQueryFilter.getIndex().getIndexName());
+    Assert.assertEquals(2, dynamoDBQueryFilter.getKeyConditions().size());
+    assertKeyCondition(COLUMN1_NAME, COLUMN1_VALUE, dynamoDBQueryFilter);
+    assertKeyCondition(RANGE_KEY_NAME, RANGE_KEY_VALUE, dynamoDBQueryFilter);
+  }
+
+  @Test
+  public void testPredicateToDynamoDBFilterWithGSIHashKeyOnly() {
+    ExprNodeDesc combinedPredicate = buildPredicate(Lists.newArrayList(
+        rangeKeyPredicate,
+        column1Predicate));
+
+    GlobalSecondaryIndexDescription gsi = createGSI(GLOBAL_SECONDARY_INDEX_NAME,
+        COLUMN1_NAME, COLUMN2_NAME, ProjectionType.ALL.toString(), null);
+
+    DynamoDBQueryFilter dynamoDBQueryFilter = dynamoDBFilterPushdown.predicateToDynamoDBFilter(
+        tableKeySchema, null, Lists.newArrayList(gsi),
+        hiveDynamoDBMapping, hiveTypeMapping, combinedPredicate);
+
+    Assert.assertNull(dynamoDBQueryFilter.getIndex());
+    Assert.assertEquals(0, dynamoDBQueryFilter.getKeyConditions().size());
+  }
+
+  @Test
+  public void testPredicateToDynamoDBFilterWithoutAnyMatchedGSI() {
+    ExprNodeDesc combinedPredicate = buildPredicate(Lists.newArrayList(
+        rangeKeyPredicate,
+        column2Predicate));
+
+    GlobalSecondaryIndexDescription gsi = createGSI(GLOBAL_SECONDARY_INDEX_NAME,
+        COLUMN1_NAME, COLUMN2_NAME, ProjectionType.ALL.toString(), null);
+
+    DynamoDBQueryFilter dynamoDBQueryFilter = dynamoDBFilterPushdown.predicateToDynamoDBFilter(
+        tableKeySchema, null, Lists.newArrayList(gsi),
+        hiveDynamoDBMapping, hiveTypeMapping, combinedPredicate);
+
+    Assert.assertNull(dynamoDBQueryFilter.getIndex());
+    Assert.assertEquals(0, dynamoDBQueryFilter.getKeyConditions().size());
+  }
+
+  private ExprNodeDesc buildPredicate(List<ExprNodeDesc> predicates) {
+    ExprNodeDesc combinedPredicate = null;
+    for (ExprNodeDesc predicate : predicates) {
+      if (combinedPredicate == null) {
+        combinedPredicate = predicate;
+        continue;
+      }
+      List<ExprNodeDesc> children = new ArrayList<>();
+      children.add(combinedPredicate);
+      children.add(predicate);
+      combinedPredicate = new ExprNodeGenericFuncDesc(
+          TypeInfoFactory.booleanTypeInfo,
+          FunctionRegistry.getGenericUDFForAnd(),
+          children);
+    }
+    return combinedPredicate;
+  }
+
+  private List<KeySchemaElement> createKeySchema(String hashKeyName, String rangeKeyName) {
+    List<KeySchemaElement> schema = new ArrayList<>();
+    schema.add(new KeySchemaElement(hashKeyName, HASH_KEY_TYPE));
+    if (rangeKeyName != null) {
+      schema.add(new KeySchemaElement(rangeKeyName, RANGE_KEY_TYPE));
+    }
+    return schema;
+  }
+
+  private Map<String, String> initHiveDynamoDBMapping() {
+    Map<String, String> hiveDynamoDBMapping = new HashMap<>();
+    hiveDynamoDBMapping.put(HASH_KEY_NAME, HASH_KEY_NAME);
+    hiveDynamoDBMapping.put(RANGE_KEY_NAME, RANGE_KEY_NAME);
+    hiveDynamoDBMapping.put(COLUMN1_NAME, COLUMN1_NAME);
+    hiveDynamoDBMapping.put(COLUMN2_NAME, COLUMN2_NAME);
+    hiveDynamoDBMapping.put(COLUMN3_NAME, COLUMN3_NAME);
+    hiveDynamoDBMapping.put(COLUMN4_NAME, COLUMN4_NAME);
+    return hiveDynamoDBMapping;
+  }
+
+  private Map<String, String> initHiveTypeMapping() {
+    Map<String, String> hiveTypeMapping = new HashMap<>();
+    hiveTypeMapping.put(HASH_KEY_NAME, serdeConstants.STRING_TYPE_NAME);
+    hiveTypeMapping.put(RANGE_KEY_NAME, serdeConstants.STRING_TYPE_NAME);
+    hiveTypeMapping.put(COLUMN1_NAME, serdeConstants.STRING_TYPE_NAME);
+    hiveTypeMapping.put(COLUMN2_NAME, serdeConstants.STRING_TYPE_NAME);
+    hiveTypeMapping.put(COLUMN3_NAME, serdeConstants.STRING_TYPE_NAME);
+    hiveTypeMapping.put(COLUMN4_NAME, serdeConstants.STRING_TYPE_NAME);
+    return  hiveTypeMapping;
+  }
+
+  private GlobalSecondaryIndexDescription createGSI(String indexName, String hashKeyName,
+      String rangeKeyName, String projectionType, List<String> nonKeyAttributes) {
+    List<KeySchemaElement> schema = createKeySchema(hashKeyName, rangeKeyName);
+    Projection projection = new Projection()
+        .withProjectionType(projectionType)
+        .withNonKeyAttributes(nonKeyAttributes);
+    return new GlobalSecondaryIndexDescription()
+        .withIndexName(indexName)
+        .withKeySchema(schema)
+        .withProjection(projection);
+  }
+
+  private LocalSecondaryIndexDescription createLSI(String indexName, String hashKeyName,
+      String rangeKeyName, String projectionType, List<String> nonKeyAttributes) {
+    List<KeySchemaElement> schema = createKeySchema(hashKeyName, rangeKeyName);
+    Projection projection = new Projection()
+        .withProjectionType(projectionType)
+        .withNonKeyAttributes(nonKeyAttributes);
+    return new LocalSecondaryIndexDescription()
+        .withIndexName(indexName)
+        .withKeySchema(schema)
+        .withProjection(projection);
+  }
+
+  private void assertKeyCondition(String columnName, String columnValue,
+      DynamoDBQueryFilter filter) {
+    Condition hashKeyCondition = new Condition();
+    List<AttributeValue> hashKeyAttributeValueList = new ArrayList<>();
+    hashKeyAttributeValueList.add(new AttributeValue(columnValue));
+    hashKeyCondition.setAttributeValueList(hashKeyAttributeValueList);
+    hashKeyCondition.setComparisonOperator(DynamoDBFilterOperator.EQ.getDynamoDBName());
+    Assert.assertEquals((hashKeyCondition.toString()),
+        filter.getKeyConditions().get(columnName).toString());
+  }
+}


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/emr-dynamodb-connector/issues/87
https://github.com/awslabs/emr-dynamodb-connector/issues/102

*Description of changes:*
* Check LSIs and GSIs for optimal pushdown key conditions if not both hash key and range key for the DynamoDB table are found in query predicate
* Pull analyzer initialization outside methods
* Update pushdown eligibleHiveType to include binary type since it is also allowed for primary key attributes according to [Amazon DynamoDB doc](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.CoreComponents.html#HowItWorks.CoreComponents.PrimaryKey)
* Add unit tests for DynamoDBFilterPushdown.java

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
