### PR TITLE
Allow Autoscaling consideration for job throughput

### DIFF
--- a/emr-dynamodb-tools/src/main/java/org/apache/hadoop/dynamodb/tools/DynamoDBExport.java
+++ b/emr-dynamodb-tools/src/main/java/org/apache/hadoop/dynamodb/tools/DynamoDBExport.java
@@ -15,7 +15,9 @@ package org.apache.hadoop.dynamodb.tools;
 
 import com.amazonaws.services.dynamodbv2.model.TableDescription;
 import com.amazonaws.services.applicationautoscaling.AWSApplicationAutoScalingClient;
-import com.amazonaws.services.applicationautoscaling.model.DescribeScalableTargetsResult;
+import com.amazonaws.services.applicationautoscaling.model.DescribeScalableTargetsRequest;
+import com.amazonaws.services.applicationautoscaling.model.ScalableDimension;
+import com.amazonaws.services.applicationautoscaling.model.ServiceNamespace;
 import java.util.Date;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;


### PR DESCRIPTION
**Issue #**
- [issue 28](https://github.com/awslabs/emr-dynamodb-connector/issues/28)

**Description of changes:**
- Autoscaling considered when determining job throughput.  Previously, enabling autoscale would set the provisioned amount to the min value or 1 (not null as was an issue in a previous PR for [issue 28](https://github.com/awslabs/emr-dynamodb-connector/issues/28)
- Use the max capacity from any autoscaling provisioning

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
