### PR TITLE
Upgrade AWS SDK Java from 1.x to 2.x

### DIFF
--- a/emr-dynamodb-hadoop/pom.xml
+++ b/emr-dynamodb-hadoop/pom.xml
@@ -94,6 +94,13 @@
                     <maxAllowedViolations>0</maxAllowedViolations>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <configuration>
+                    <appendAssemblyId>false</appendAssemblyId>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/emr-dynamodb-hadoop/pom.xml
+++ b/emr-dynamodb-hadoop/pom.xml
@@ -54,8 +54,13 @@
         </dependency>
 
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-dynamodb</artifactId>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>dynamodb</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>apache-client</artifactId>
         </dependency>
 
         <dependency>

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/AttributeValueDeserializer.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/AttributeValueDeserializer.java
@@ -1,0 +1,120 @@
+/**
+ * Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+ * except in compliance with the License. A copy of the License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "LICENSE.TXT" file accompanying this file. This file is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under the License.
+ */
+
+package org.apache.hadoop.dynamodb;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.hadoop.dynamodb.type.DynamoDBTypeConstants;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+public class AttributeValueDeserializer implements JsonDeserializer<AttributeValue> {
+
+  @Override
+  public AttributeValue deserialize(JsonElement jsonElement, Type type,
+                                    JsonDeserializationContext context) throws JsonParseException {
+    if (jsonElement.isJsonNull()) {
+      return null;
+    }
+
+    if (jsonElement.isJsonObject()) {
+      JsonObject jsonObject = jsonElement.getAsJsonObject();
+
+      for (Map.Entry<String, JsonElement> entry : jsonObject.entrySet()) {
+        String attributeName = entry.getKey();
+        JsonElement attributeValue = entry.getValue();
+
+        if (DynamoDBTypeConstants.BINARY.equalsIgnoreCase(attributeName)) {
+          return AttributeValue.fromB(context.deserialize(attributeValue, SdkBytes.class));
+        }
+
+        if (DynamoDBTypeConstants.BINARY_SET.equalsIgnoreCase(attributeName)) {
+          JsonArray jsonArray = attributeValue.getAsJsonArray();
+          if (!jsonArray.isEmpty()) {
+            List<SdkBytes> sdkBytesList = new ArrayList<>();
+            jsonArray.forEach(item -> sdkBytesList.add(context.deserialize(item, SdkBytes.class)));
+            return AttributeValue.fromBs(sdkBytesList);
+          }
+        }
+
+        if (DynamoDBTypeConstants.BOOLEAN.equalsIgnoreCase(attributeName)) {
+          return AttributeValue.fromBool(attributeValue.getAsBoolean());
+        }
+
+        if (DynamoDBTypeConstants.NULL.equalsIgnoreCase(attributeName)) {
+          return AttributeValue.fromNul(attributeValue.getAsBoolean());
+        }
+
+        if (DynamoDBTypeConstants.NUMBER.equalsIgnoreCase(attributeName)) {
+          return AttributeValue.fromN(attributeValue.getAsString());
+        }
+
+        if (DynamoDBTypeConstants.NUMBER_SET.equalsIgnoreCase(attributeName)) {
+          JsonArray jsonArray = attributeValue.getAsJsonArray();
+          if (!jsonArray.isEmpty()) {
+            List<String> numberList = new ArrayList<>();
+            jsonArray.forEach(item -> numberList.add(item.getAsString()));
+            return AttributeValue.fromNs(numberList);
+          }
+        }
+
+        if (DynamoDBTypeConstants.LIST.equalsIgnoreCase(attributeName)) {
+          JsonArray jsonArray = attributeValue.getAsJsonArray();
+          if (!jsonArray.isEmpty()) {
+            List<AttributeValue> avl = new ArrayList<>();
+            jsonArray.forEach(element ->
+                avl.add(context.deserialize(element, AttributeValue.class)));
+            return AttributeValue.fromL(avl);
+          }
+        }
+
+        if (DynamoDBTypeConstants.MAP.equalsIgnoreCase(attributeName)) {
+          JsonObject jsonMap = attributeValue.getAsJsonObject();
+          if (jsonMap.size() != 0) {
+            Map<String, AttributeValue> avm = new HashMap<>();
+            jsonMap.entrySet().forEach(item -> {
+              avm.put(item.getKey(), context.deserialize(item.getValue(), AttributeValue.class));
+            });
+            return AttributeValue.fromM(avm);
+          }
+        }
+
+        if (DynamoDBTypeConstants.STRING.equalsIgnoreCase(attributeName)) {
+          return AttributeValue.fromS(attributeValue.getAsString());
+        }
+
+        if (DynamoDBTypeConstants.STRING_SET.equalsIgnoreCase(attributeName)) {
+          JsonArray jsonArray = attributeValue.getAsJsonArray();
+          if (!jsonArray.isEmpty()) {
+            List<String> stringList = new ArrayList<>();
+            jsonArray.forEach(item -> stringList.add(item.getAsString()));
+            return AttributeValue.fromSs(stringList);
+          }
+        }
+      }
+    }
+
+    // Return an empty instance as default value.
+    return AttributeValue.builder().build();
+  }
+}

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/AttributeValueSerializer.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/AttributeValueSerializer.java
@@ -37,57 +37,61 @@ public class AttributeValueSerializer implements JsonSerializer<AttributeValue> 
     JsonObject serializedValue = new JsonObject();
     switch (attributeValue.type()) {
       case B:
-        serializedValue.add(DynamoDBTypeConstants.BINARY.toLowerCase(),
+        serializedValue.add(toV1FieldCasingStyle(DynamoDBTypeConstants.BINARY),
             context.serialize(attributeValue.b()));
         break;
       case BOOL:
-        serializedValue.add(DynamoDBTypeConstants.BOOLEAN.toLowerCase(),
+        serializedValue.add(toV1FieldCasingStyle(DynamoDBTypeConstants.BOOLEAN),
             new JsonPrimitive(attributeValue.bool()));
         break;
       case BS:
         JsonArray sdkBytesList = new JsonArray();
         attributeValue.bs()
             .forEach(item -> sdkBytesList.add(context.serialize(item, SdkBytes.class)));
-        serializedValue.add(DynamoDBTypeConstants.BINARY_SET.toLowerCase(), sdkBytesList);
+        serializedValue.add(toV1FieldCasingStyle(DynamoDBTypeConstants.BINARY_SET), sdkBytesList);
         break;
       case L:
         JsonArray attributeList = new JsonArray();
         attributeValue.l()
             .forEach(item -> attributeList.add(context.serialize(item, AttributeValue.class)));
-        serializedValue.add(DynamoDBTypeConstants.LIST.toLowerCase(), attributeList);
+        serializedValue.add(toV1FieldCasingStyle(DynamoDBTypeConstants.LIST), attributeList);
         break;
       case M:
         JsonObject avm = new JsonObject();
         attributeValue.m().entrySet()
             .forEach(entry ->
                 avm.add(entry.getKey(), context.serialize(entry.getValue(), AttributeValue.class)));
-        serializedValue.add(DynamoDBTypeConstants.MAP.toLowerCase(), avm);
+        serializedValue.add(toV1FieldCasingStyle(DynamoDBTypeConstants.MAP), avm);
         break;
       case N:
-        serializedValue.add(DynamoDBTypeConstants.NUMBER.toLowerCase(),
+        serializedValue.add(toV1FieldCasingStyle(DynamoDBTypeConstants.NUMBER),
             new JsonPrimitive(attributeValue.n()));
         break;
       case NS:
         JsonArray numberList = new JsonArray();
         attributeValue.ns().forEach(item -> numberList.add(new JsonPrimitive(item)));
-        serializedValue.add(DynamoDBTypeConstants.NUMBER_SET.toLowerCase(), numberList);
+        serializedValue.add(toV1FieldCasingStyle(DynamoDBTypeConstants.NUMBER_SET), numberList);
         break;
       case NUL:
-        serializedValue.add(DynamoDBTypeConstants.NULL.toLowerCase(),
+        serializedValue.add(toV1FieldCasingStyle(DynamoDBTypeConstants.NULL),
             new JsonPrimitive(attributeValue.nul()));
         break;
       case S:
-        serializedValue.add(DynamoDBTypeConstants.STRING.toLowerCase(),
+        serializedValue.add(toV1FieldCasingStyle(DynamoDBTypeConstants.STRING),
             new JsonPrimitive(attributeValue.s()));
         break;
       case SS:
         JsonArray stringList = new JsonArray();
         attributeValue.ss().forEach(item -> stringList.add(new JsonPrimitive(item)));
-        serializedValue.add(DynamoDBTypeConstants.STRING_SET.toLowerCase(), stringList);
+        serializedValue.add(toV1FieldCasingStyle(DynamoDBTypeConstants.STRING_SET), stringList);
         break;
       default:
         break;
     }
     return serializedValue;
+  }
+
+  private static String toV1FieldCasingStyle(String typeConstant) {
+    return typeConstant.substring(0, 1).toLowerCase() + typeConstant.substring(1).toUpperCase();
   }
 }

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/AttributeValueSerializer.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/AttributeValueSerializer.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+ * except in compliance with the License. A copy of the License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "LICENSE.TXT" file accompanying this file. This file is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under the License.
+ */
+
+package org.apache.hadoop.dynamodb;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonNull;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+import java.lang.reflect.Type;
+import org.apache.hadoop.dynamodb.type.DynamoDBTypeConstants;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+public class AttributeValueSerializer implements JsonSerializer<AttributeValue> {
+
+  @Override
+  public JsonElement serialize(AttributeValue attributeValue, Type type,
+                               JsonSerializationContext context) {
+    if (attributeValue == null) {
+      return JsonNull.INSTANCE;
+    }
+
+    JsonObject serializedValue = new JsonObject();
+    switch (attributeValue.type()) {
+      case B:
+        serializedValue.add(DynamoDBTypeConstants.BINARY.toLowerCase(),
+            context.serialize(attributeValue.b()));
+        break;
+      case BOOL:
+        serializedValue.add(DynamoDBTypeConstants.BOOLEAN.toLowerCase(),
+            new JsonPrimitive(attributeValue.bool()));
+        break;
+      case BS:
+        JsonArray sdkBytesList = new JsonArray();
+        attributeValue.bs()
+            .forEach(item -> sdkBytesList.add(context.serialize(item, SdkBytes.class)));
+        serializedValue.add(DynamoDBTypeConstants.BINARY_SET.toLowerCase(), sdkBytesList);
+        break;
+      case L:
+        JsonArray attributeList = new JsonArray();
+        attributeValue.l()
+            .forEach(item -> attributeList.add(context.serialize(item, AttributeValue.class)));
+        serializedValue.add(DynamoDBTypeConstants.LIST.toLowerCase(), attributeList);
+        break;
+      case M:
+        JsonObject avm = new JsonObject();
+        attributeValue.m().entrySet()
+            .forEach(entry ->
+                avm.add(entry.getKey(), context.serialize(entry.getValue(), AttributeValue.class)));
+        serializedValue.add(DynamoDBTypeConstants.MAP.toLowerCase(), avm);
+        break;
+      case N:
+        serializedValue.add(DynamoDBTypeConstants.NUMBER.toLowerCase(),
+            new JsonPrimitive(attributeValue.n()));
+        break;
+      case NS:
+        JsonArray numberList = new JsonArray();
+        attributeValue.ns().forEach(item -> numberList.add(new JsonPrimitive(item)));
+        serializedValue.add(DynamoDBTypeConstants.NUMBER_SET.toLowerCase(), numberList);
+        break;
+      case NUL:
+        serializedValue.add(DynamoDBTypeConstants.NULL.toLowerCase(),
+            new JsonPrimitive(attributeValue.nul()));
+        break;
+      case S:
+        serializedValue.add(DynamoDBTypeConstants.STRING.toLowerCase(),
+            new JsonPrimitive(attributeValue.s()));
+        break;
+      case SS:
+        JsonArray stringList = new JsonArray();
+        attributeValue.ss().forEach(item -> stringList.add(new JsonPrimitive(item)));
+        serializedValue.add(DynamoDBTypeConstants.STRING_SET.toLowerCase(), stringList);
+        break;
+      default:
+        break;
+    }
+    return serializedValue;
+  }
+}

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBClient.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBClient.java
@@ -421,7 +421,7 @@ public class DynamoDBClient {
     final String proxyPassword = conf.get(DynamoDBConstants.PROXY_PASSWORD);
     boolean proxyHostAndPortPresent = false;
     if (!Strings.isNullOrEmpty(proxyHost) && proxyPort > 0) {
-      builder.endpoint(URI.create(proxyHost + ":" + proxyPort));
+      builder.endpoint(buildProxyEndpoint(proxyHost, proxyPort));
       proxyHostAndPortPresent = true;
     } else if (Strings.isNullOrEmpty(proxyHost) ^ proxyPort <= 0) {
       throw new RuntimeException("Only one of proxy host and port are set, when both are required");
@@ -493,4 +493,10 @@ public class DynamoDBClient {
     return providerChain;
   }
 
+  private URI buildProxyEndpoint(String proxyHost, int proxyPort) {
+    // Default proxy protocol is HTTP, aligning with AWS Java SDK 1.x
+    // https://github.com/aws/aws-sdk-java/blob/master/aws-java-sdk-core/src/main/java/com/amazonaws/ClientConfiguration.java#L171
+    final String HTTP_PROTOCOL = "http://";
+    return URI.create(HTTP_PROTOCOL + proxyHost + ":" + proxyPort);
+  }
 }

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBConstants.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBConstants.java
@@ -13,8 +13,8 @@
 
 package org.apache.hadoop.dynamodb;
 
-import com.amazonaws.regions.Regions;
-import com.amazonaws.services.dynamodbv2.model.BillingMode;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.dynamodb.model.BillingMode;
 
 /**
  * Contains constants used for the Hadoop to DynamoDB connection. Note that many of these string
@@ -104,7 +104,7 @@ public interface DynamoDBConstants {
   int RATE_CONTROLLER_WINDOW_SIZE_SEC = 5;
 
   String EXPORT_FORMAT_VERSION = "dynamodb.export.format.version";
-  String DEFAULT_AWS_REGION = Regions.US_EAST_1.getName();
+  String DEFAULT_AWS_REGION = Region.US_EAST_1.toString();
 
   int DEFAULT_AVERAGE_ITEM_SIZE_IN_BYTES = 100;
   Long DEFAULT_CAPACITY_FOR_ON_DEMAND = 40000L;

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBItemWritable.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBItemWritable.java
@@ -13,7 +13,6 @@
 
 package org.apache.hadoop.dynamodb;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import java.io.ByteArrayInputStream;
@@ -27,6 +26,7 @@ import java.lang.reflect.Type;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.hadoop.io.Writable;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 public class DynamoDBItemWritable implements Writable, Serializable {
 

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBUtil.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBUtil.java
@@ -65,6 +65,10 @@ public final class DynamoDBUtil {
     /* We hand serialize/deserialize ByteBuffer objects. */
     gsonBuilder.registerTypeAdapter(ByteBuffer.class, new ByteBufferSerializer());
     gsonBuilder.registerTypeAdapter(ByteBuffer.class, new ByteBufferDeserializer());
+    gsonBuilder.registerTypeAdapter(SdkBytes.class, new SdkBytesSerializer());
+    gsonBuilder.registerTypeAdapter(SdkBytes.class, new SdkBytesDeserializer());
+    gsonBuilder.registerTypeAdapter(AttributeValue.class, new AttributeValueSerializer());
+    gsonBuilder.registerTypeAdapter(AttributeValue.class, new AttributeValueDeserializer());
 
     gson = gsonBuilder.disableHtmlEscaping().create();
   }
@@ -369,6 +373,28 @@ public final class DynamoDBUtil {
 
       String base64String = jsonElement.getAsJsonPrimitive().getAsString();
       return DynamoDBUtil.base64StringToByteBuffer(base64String);
+    }
+  }
+
+  private static class SdkBytesSerializer implements JsonSerializer<SdkBytes> {
+
+    @Override
+    public JsonElement serialize(SdkBytes sdkBytes, Type type, JsonSerializationContext
+        context) {
+
+      String base64String = DynamoDBUtil.base64EncodeByteArray(sdkBytes.asByteArray());
+      return new JsonPrimitive(base64String);
+    }
+  }
+
+  private static class SdkBytesDeserializer implements JsonDeserializer<SdkBytes> {
+
+    @Override
+    public SdkBytes deserialize(JsonElement jsonElement, Type type, JsonDeserializationContext
+        context) throws JsonParseException {
+
+      String base64String = jsonElement.getAsJsonPrimitive().getAsString();
+      return SdkBytes.fromByteBuffer(DynamoDBUtil.base64StringToByteBuffer(base64String));
     }
   }
 

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBUtil.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBUtil.java
@@ -217,17 +217,7 @@ public final class DynamoDBUtil {
   }
 
   /**
-   * Calculates DynamoDB end-point.
-   *
-   * Algorithm details:
-   * <ol>
-   * <li> Use endpoint in job configuration "dynamodb.endpoint" value if available
-   * <li> Use endpoint from region in job configuration "dynamodb.region" value if available
-   * <li> Use endpoint from region in job configuration "dynamodb.regionid" value if available
-   * <li> Use endpoint from EC2 Metadata of instance if available
-   * <li> If all previous attempts at retrieving endpoint fail, default to us-east-1 endpoint
-   * </ol>
-   *
+   * Get custom DynamoDB end-point from configuration.
    * @param conf   Job Configuration
    * @param region optional preferred region
    * @return end-point for DynamoDb service
@@ -236,33 +226,27 @@ public final class DynamoDBUtil {
     String endpoint = getValueFromConf(conf, DynamoDBConstants.ENDPOINT);
     if (Strings.isNullOrEmpty(endpoint)) {
       log.info(DynamoDBConstants.ENDPOINT + " not found from configuration.");
-      /*
-      if (Strings.isNullOrEmpty(region)) {
-        region = getValueFromConf(conf, DynamoDBConstants.REGION);
-      }
-      if (Strings.isNullOrEmpty(region)) {
-        region = getValueFromConf(conf, DynamoDBConstants.REGION_ID);
-      }
-      if (Strings.isNullOrEmpty(region)) {
-        try {
-          region = EC2MetadataUtils.getEC2InstanceRegion();
-        } catch (Exception e) {
-          log.warn(String.format("Exception when attempting to get AWS region information. Will "
-              + "ignore and default " + "to %s", DynamoDBConstants.DEFAULT_AWS_REGION), e);
-        }
-      }
-      if (Strings.isNullOrEmpty(region)) {
-        region = DynamoDBConstants.DEFAULT_AWS_REGION;
-      }
-
-      endpoint = DynamoDbClient.serviceMetadata().endpointFor(Region.of(region)).toString();
-      */
     } else {
       log.info("Using endpoint for DynamoDB: " + endpoint);
     }
     return endpoint;
   }
 
+  /**
+   * Calculates DynamoDB region.
+   *
+   * Algorithm details:
+   * <ol>
+   * <li> Use region in job configuration "dynamodb.region" value if available
+   * <li> Use region in job configuration "dynamodb.regionid" value if available
+   * <li> Use endpoint from EC2 Metadata of instance if available
+   * <li> If all previous attempts fail, default to us-east-1 region
+   * </ol>
+   *
+   * @param conf
+   * @param region
+   * @return region for DynamoDB service
+   */
   public static String getDynamoDBRegion(Configuration conf, String region) {
     if (!Strings.isNullOrEmpty(region)) {
       return region;

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBUtil.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBUtil.java
@@ -171,24 +171,24 @@ public final class DynamoDBUtil {
       byteSize += att.s().getBytes(CHARACTER_ENCODING).length;
     } else if (att.b() != null) {
       byteSize += att.b().asByteBuffer().array().length;
-    } else if (att.ns() != null) {
+    } else if (att.hasNs()) {
       for (String number : att.ns()) {
         byteSize += number.getBytes(CHARACTER_ENCODING).length;
       }
-    } else if (att.ss() != null) {
+    } else if (att.hasSs()) {
       for (String string : att.ss()) {
         byteSize += string.getBytes(CHARACTER_ENCODING).length;
       }
-    } else if (att.bs() != null) {
+    } else if (att.hasBs()) {
       for (SdkBytes sdkBytes : att.bs()) {
         byteSize += sdkBytes.asByteBuffer().array().length;
       }
-    } else if (att.m() != null) {
+    } else if (att.hasM()) {
       for (Entry<String, AttributeValue> entry : att.m().entrySet()) {
         byteSize += getAttributeSizeBytes(entry.getValue())
             + entry.getKey().getBytes(CHARACTER_ENCODING).length;
       }
-    } else if (att.l() != null) {
+    } else if (att.hasL()) {
       for (AttributeValue entry : att.l()) {
         byteSize += getAttributeSizeBytes(entry);
       }

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBUtil.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBUtil.java
@@ -174,7 +174,7 @@ public final class DynamoDBUtil {
     } else if (att.s() != null) {
       byteSize += att.s().getBytes(CHARACTER_ENCODING).length;
     } else if (att.b() != null) {
-      byteSize += att.b().asByteBuffer().array().length;
+      byteSize += att.b().asByteArray().length;
     } else if (att.hasNs()) {
       for (String number : att.ns()) {
         byteSize += number.getBytes(CHARACTER_ENCODING).length;
@@ -185,7 +185,7 @@ public final class DynamoDBUtil {
       }
     } else if (att.hasBs()) {
       for (SdkBytes sdkBytes : att.bs()) {
-        byteSize += sdkBytes.asByteBuffer().array().length;
+        byteSize += sdkBytes.asByteArray().length;
       }
     } else if (att.hasM()) {
       for (Entry<String, AttributeValue> entry : att.m().entrySet()) {

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/filter/DynamoDBFilter.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/filter/DynamoDBFilter.java
@@ -13,7 +13,7 @@
 
 package org.apache.hadoop.dynamodb.filter;
 
-import com.amazonaws.services.dynamodbv2.model.Condition;
+import software.amazon.awssdk.services.dynamodb.model.Condition;
 
 public interface DynamoDBFilter {
   String getColumnName();

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/filter/DynamoDBIndexInfo.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/filter/DynamoDBIndexInfo.java
@@ -1,8 +1,8 @@
 package org.apache.hadoop.dynamodb.filter;
 
-import com.amazonaws.services.dynamodbv2.model.KeySchemaElement;
-import com.amazonaws.services.dynamodbv2.model.Projection;
 import java.util.List;
+import software.amazon.awssdk.services.dynamodb.model.KeySchemaElement;
+import software.amazon.awssdk.services.dynamodb.model.Projection;
 
 public class DynamoDBIndexInfo {
 

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/filter/DynamoDBQueryFilter.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/filter/DynamoDBQueryFilter.java
@@ -13,9 +13,9 @@
 
 package org.apache.hadoop.dynamodb.filter;
 
-import com.amazonaws.services.dynamodbv2.model.Condition;
 import java.util.HashMap;
 import java.util.Map;
+import software.amazon.awssdk.services.dynamodb.model.Condition;
 
 public class DynamoDBQueryFilter {
 

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/key/DynamoDBBinaryKey.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/key/DynamoDBBinaryKey.java
@@ -13,9 +13,9 @@
 
 package org.apache.hadoop.dynamodb.key;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import java.nio.ByteBuffer;
 import org.apache.hadoop.dynamodb.DynamoDBUtil;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 public class DynamoDBBinaryKey extends AbstractDynamoDBKey {
 
@@ -28,6 +28,6 @@ public class DynamoDBBinaryKey extends AbstractDynamoDBKey {
 
   @Override
   public int compareValue(AttributeValue attribute) {
-    return byteBuffer.compareTo(attribute.getB());
+    return byteBuffer.compareTo(attribute.b().asByteBuffer());
   }
 }

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/key/DynamoDBBooleanKey.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/key/DynamoDBBooleanKey.java
@@ -13,7 +13,7 @@
 
 package org.apache.hadoop.dynamodb.key;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 
 public class DynamoDBBooleanKey  extends AbstractDynamoDBKey {
@@ -24,7 +24,7 @@ public class DynamoDBBooleanKey  extends AbstractDynamoDBKey {
 
   @Override
   public int compareValue(AttributeValue attribute) {
-    return new Boolean(key).compareTo(attribute.getBOOL());
+    return new Boolean(key).compareTo(attribute.bool());
   }
 
 }

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/key/DynamoDBKey.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/key/DynamoDBKey.java
@@ -13,7 +13,7 @@
 
 package org.apache.hadoop.dynamodb.key;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 public interface DynamoDBKey {
 

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/key/DynamoDBNumberKey.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/key/DynamoDBNumberKey.java
@@ -13,8 +13,8 @@
 
 package org.apache.hadoop.dynamodb.key;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import java.math.BigDecimal;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 public class DynamoDBNumberKey extends AbstractDynamoDBKey {
 
@@ -26,7 +26,7 @@ public class DynamoDBNumberKey extends AbstractDynamoDBKey {
 
   @Override
   public int compareValue(AttributeValue attribute) {
-    BigDecimal passedKey = new BigDecimal(attribute.getN());
+    BigDecimal passedKey = new BigDecimal(attribute.n());
     if (number == null) {
       number = new BigDecimal(key);
     }

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/key/DynamoDBStringKey.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/key/DynamoDBStringKey.java
@@ -13,7 +13,7 @@
 
 package org.apache.hadoop.dynamodb.key;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 public class DynamoDBStringKey extends AbstractDynamoDBKey {
 
@@ -23,6 +23,6 @@ public class DynamoDBStringKey extends AbstractDynamoDBKey {
 
   @Override
   public int compareValue(AttributeValue attribute) {
-    return key.compareTo(attribute.getS());
+    return key.compareTo(attribute.s());
   }
 }

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/preader/AbstractReadManager.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/preader/AbstractReadManager.java
@@ -13,7 +13,6 @@
 
 package org.apache.hadoop.dynamodb.preader;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import java.util.ArrayList;
 import java.util.Deque;
 import java.util.List;
@@ -26,6 +25,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.dynamodb.DynamoDBConstants;
 import org.apache.hadoop.dynamodb.util.AbstractTimeSource;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
  * The ReadManager is responsible for deciding the required number of ReadWorkers to achieve the

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/preader/AbstractRecordReadRequest.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/preader/AbstractRecordReadRequest.java
@@ -13,10 +13,10 @@
 
 package org.apache.hadoop.dynamodb.preader;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import java.util.Map;
 import org.apache.hadoop.dynamodb.DynamoDBConstants;
 import org.apache.hadoop.dynamodb.preader.RateController.RequestLimit;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 public abstract class AbstractRecordReadRequest {
 

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/preader/DynamoDBRecordReaderContext.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/preader/DynamoDBRecordReaderContext.java
@@ -13,7 +13,6 @@
 
 package org.apache.hadoop.dynamodb.preader;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import java.util.Collection;
 import java.util.Map;
 import org.apache.hadoop.dynamodb.DynamoDBClient;
@@ -21,6 +20,7 @@ import org.apache.hadoop.dynamodb.split.DynamoDBSplit;
 import org.apache.hadoop.mapred.InputSplit;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.Reporter;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 public class DynamoDBRecordReaderContext {
 

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/preader/QueryRecordReadRequest.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/preader/QueryRecordReadRequest.java
@@ -41,7 +41,12 @@ public class QueryRecordReadRequest extends AbstractRecordReadRequest {
     QueryResponse response = retryResult.result;
     int retries = retryResult.retries;
 
-    return new PageResults<>(response.items(), response.lastEvaluatedKey(),
-            response.consumedCapacity().capacityUnits(), retries);
+    return new PageResults<>(response.items(),
+        // Default value of QueryResponse.lastEvaluatedKey is changed from NULL to
+        // SdkAutoConstructMap in AWS SDK 2.x.
+        // Translate the default value to NULL here, to keep this assumption in other classes.
+        response.hasLastEvaluatedKey() ? response.lastEvaluatedKey() : null,
+        response.consumedCapacity().capacityUnits(),
+        retries);
   }
 }

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/preader/QueryRecordReadRequest.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/preader/QueryRecordReadRequest.java
@@ -1,11 +1,11 @@
 /**
  * Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
  * except in compliance with the License. A copy of the License is located at
- *
+ * <p>
  *     http://aws.amazon.com/apache2.0/
- *
+ * <p>
  * or in the "LICENSE.TXT" file accompanying this file. This file is distributed on an "AS IS"
  * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under the License.
@@ -13,35 +13,35 @@
 
 package org.apache.hadoop.dynamodb.preader;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
-import com.amazonaws.services.dynamodbv2.model.QueryResult;
 import java.util.Map;
 import org.apache.hadoop.dynamodb.DynamoDBFibonacciRetryer.RetryResult;
 import org.apache.hadoop.dynamodb.preader.RateController.RequestLimit;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.QueryResponse;
 
 public class QueryRecordReadRequest extends AbstractRecordReadRequest {
 
   public QueryRecordReadRequest(AbstractReadManager readMgr, DynamoDBRecordReaderContext context,
-      Map<String, AttributeValue> lastEvaluatedKey) {
+                                Map<String, AttributeValue> lastEvaluatedKey) {
     super(readMgr, context, 0 /* segment */, lastEvaluatedKey);
   }
 
   @Override
   protected AbstractRecordReadRequest buildNextReadRequest(PageResults<Map<String,
-      AttributeValue>> pageResults) {
+          AttributeValue>> pageResults) {
     return new QueryRecordReadRequest(readMgr, context, pageResults.lastEvaluatedKey);
   }
 
   @Override
   protected PageResults<Map<String, AttributeValue>> fetchPage(RequestLimit lim) {
     // Read from DynamoDB
-    RetryResult<QueryResult> retryResult = context.getClient().queryTable(tableName, context
-        .getSplit().getFilterPushdown(), lastEvaluatedKey, lim.items, context.getReporter());
+    RetryResult<QueryResponse> retryResult = context.getClient().queryTable(tableName, context
+            .getSplit().getFilterPushdown(), lastEvaluatedKey, lim.items, context.getReporter());
 
-    QueryResult result = retryResult.result;
+    QueryResponse response = retryResult.result;
     int retries = retryResult.retries;
 
-    return new PageResults<>(result.getItems(), result.getLastEvaluatedKey(), result
-        .getConsumedCapacity().getCapacityUnits(), retries);
+    return new PageResults<>(response.items(), response.lastEvaluatedKey(),
+            response.consumedCapacity().capacityUnits(), retries);
   }
 }

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/preader/ScanRecordReadRequest.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/preader/ScanRecordReadRequest.java
@@ -46,7 +46,12 @@ public class ScanRecordReadRequest extends AbstractRecordReadRequest {
     if (response.consumedCapacity() != null) {
       consumedCapacityUnits = response.consumedCapacity().capacityUnits();
     }
-    return new PageResults<>(response.items(), response.lastEvaluatedKey(), consumedCapacityUnits,
+    return new PageResults<>(response.items(),
+        // Default value of ScanResponse.lastEvaluatedKey is changed from NULL to
+        // SdkAutoConstructMap in AWS SDK 2.x.
+        // Translate the default value to NULL here, to keep this assumption in other classes.
+        response.hasLastEvaluatedKey() ? response.lastEvaluatedKey() : null,
+        consumedCapacityUnits,
         retries);
   }
 }

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/preader/ScanRecordReadRequest.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/preader/ScanRecordReadRequest.java
@@ -13,11 +13,11 @@
 
 package org.apache.hadoop.dynamodb.preader;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
-import com.amazonaws.services.dynamodbv2.model.ScanResult;
 import java.util.Map;
 import org.apache.hadoop.dynamodb.DynamoDBFibonacciRetryer.RetryResult;
 import org.apache.hadoop.dynamodb.preader.RateController.RequestLimit;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.ScanResponse;
 
 public class ScanRecordReadRequest extends AbstractRecordReadRequest {
 
@@ -35,17 +35,18 @@ public class ScanRecordReadRequest extends AbstractRecordReadRequest {
   @Override
   protected PageResults<Map<String, AttributeValue>> fetchPage(RequestLimit lim) {
     // Read from DynamoDB
-    RetryResult<ScanResult> retryResult = context.getClient().scanTable(tableName, null, segment,
-        context.getSplit().getTotalSegments(), lastEvaluatedKey, lim.items, context.getReporter());
+    RetryResult<ScanResponse> retryResult = context.getClient()
+            .scanTable(tableName, null, segment, context.getSplit().getTotalSegments(),
+                    lastEvaluatedKey, lim.items, context.getReporter());
 
-    ScanResult result = retryResult.result;
+    ScanResponse response = retryResult.result;
     int retries = retryResult.retries;
 
     double consumedCapacityUnits = 0.0;
-    if (result.getConsumedCapacity() != null) {
-      consumedCapacityUnits = result.getConsumedCapacity().getCapacityUnits();
+    if (response.consumedCapacity() != null) {
+      consumedCapacityUnits = response.consumedCapacity().capacityUnits();
     }
-    return new PageResults<>(result.getItems(), result.getLastEvaluatedKey(), consumedCapacityUnits,
+    return new PageResults<>(response.items(), response.lastEvaluatedKey(), consumedCapacityUnits,
         retries);
   }
 }

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/read/AbstractDynamoDBRecordReader.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/read/AbstractDynamoDBRecordReader.java
@@ -15,7 +15,6 @@ package org.apache.hadoop.dynamodb.read;
 
 import static org.apache.hadoop.dynamodb.DynamoDBUtil.createJobClient;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import java.io.IOException;
 import java.util.Map;
 import org.apache.commons.logging.Log;
@@ -34,6 +33,7 @@ import org.apache.hadoop.dynamodb.split.DynamoDBSplit;
 import org.apache.hadoop.dynamodb.util.TimeSource;
 import org.apache.hadoop.mapred.RecordReader;
 import org.apache.hadoop.mapred.Reporter;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
  * AbstractDynamoDBRecordReader does all the backend work for splitting up the data in DynamoDB,

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/read/ReadIopsCalculator.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/read/ReadIopsCalculator.java
@@ -13,8 +13,6 @@
 
 package org.apache.hadoop.dynamodb.read;
 
-import com.amazonaws.services.dynamodbv2.model.ProvisionedThroughputDescription;
-import com.amazonaws.services.dynamodbv2.model.TableDescription;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.dynamodb.DynamoDBClient;
@@ -22,6 +20,9 @@ import org.apache.hadoop.dynamodb.DynamoDBConstants;
 import org.apache.hadoop.dynamodb.IopsCalculator;
 import org.apache.hadoop.mapred.JobClient;
 import org.apache.hadoop.mapred.JobConf;
+import software.amazon.awssdk.services.dynamodb.model.BillingMode;
+import software.amazon.awssdk.services.dynamodb.model.ProvisionedThroughputDescription;
+import software.amazon.awssdk.services.dynamodb.model.TableDescription;
 
 public class ReadIopsCalculator implements IopsCalculator {
 
@@ -66,12 +67,11 @@ public class ReadIopsCalculator implements IopsCalculator {
 
   private double getThroughput() {
     TableDescription tableDescription = dynamoDBClient.describeTable(tableName);
-    if (tableDescription.getBillingModeSummary() == null
-        || tableDescription.getBillingModeSummary().getBillingMode()
-            .equalsIgnoreCase(DynamoDBConstants.BILLING_MODE_PROVISIONED)) {
+    if (tableDescription.billingModeSummary() == null
+        || tableDescription.billingModeSummary().billingMode() == BillingMode.PROVISIONED) {
       ProvisionedThroughputDescription provisionedThroughput = tableDescription
-          .getProvisionedThroughput();
-      return provisionedThroughput.getReadCapacityUnits();
+          .provisionedThroughput();
+      return provisionedThroughput.readCapacityUnits();
     }
     return DynamoDBConstants.DEFAULT_CAPACITY_FOR_ON_DEMAND;
   }

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/type/DynamoDBBinarySetType.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/type/DynamoDBBinarySetType.java
@@ -13,15 +13,20 @@
 
 package org.apache.hadoop.dynamodb.type;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import java.util.stream.Collectors;
 import org.apache.hadoop.dynamodb.DynamoDBUtil;
 import org.apache.hadoop.dynamodb.key.DynamoDBKey;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 public class DynamoDBBinarySetType implements DynamoDBType {
 
   @Override
   public AttributeValue getAttributeValue(String... values) {
-    return new AttributeValue().withBS(DynamoDBUtil.base64StringToByteBuffer(values));
+    return AttributeValue.fromBs(DynamoDBUtil.base64StringToByteBuffer(values)
+            .stream()
+            .map(byteBuffer -> SdkBytes.fromByteBuffer(byteBuffer))
+            .collect(Collectors.toList()));
   }
 
   @Override

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/type/DynamoDBBinaryType.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/type/DynamoDBBinaryType.java
@@ -15,15 +15,16 @@ package org.apache.hadoop.dynamodb.type;
 
 import static org.apache.hadoop.dynamodb.DynamoDBUtil.base64StringToByteBuffer;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import org.apache.hadoop.dynamodb.key.DynamoDBBinaryKey;
 import org.apache.hadoop.dynamodb.key.DynamoDBKey;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 public class DynamoDBBinaryType implements DynamoDBType {
 
   @Override
   public AttributeValue getAttributeValue(String... values) {
-    return new AttributeValue().withB(base64StringToByteBuffer(values[0]));
+    return AttributeValue.fromB(SdkBytes.fromByteBuffer(base64StringToByteBuffer(values[0])));
   }
 
   @Override

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/type/DynamoDBBooleanType.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/type/DynamoDBBooleanType.java
@@ -13,16 +13,16 @@
 
 package org.apache.hadoop.dynamodb.type;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import org.apache.hadoop.dynamodb.key.DynamoDBBooleanKey;
 import org.apache.hadoop.dynamodb.key.DynamoDBKey;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 
 public class DynamoDBBooleanType implements DynamoDBType {
 
   @Override
   public AttributeValue getAttributeValue(String... values) {
-    return new AttributeValue().withBOOL(new Boolean(values[0]));
+    return AttributeValue.fromBool(new Boolean(values[0]));
   }
 
   @Override

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/type/DynamoDBListType.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/type/DynamoDBListType.java
@@ -11,18 +11,19 @@
 
 package org.apache.hadoop.dynamodb.type;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import java.util.ArrayList;
 import org.apache.hadoop.dynamodb.key.DynamoDBKey;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 public class DynamoDBListType implements DynamoDBType {
 
   @Override
   public AttributeValue getAttributeValue(String... values) {
-    AttributeValue av = new AttributeValue();
+    ArrayList<AttributeValue> avl = new ArrayList<>();
     for (String ele : values) {
-      av.withL(new AttributeValue(ele));
+      avl.add(AttributeValue.fromS(ele));
     }
-    return av;
+    return AttributeValue.fromL(avl);
   }
 
   @Override

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/type/DynamoDBMapType.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/type/DynamoDBMapType.java
@@ -11,8 +11,8 @@
 
 package org.apache.hadoop.dynamodb.type;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import org.apache.hadoop.dynamodb.key.DynamoDBKey;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 public class DynamoDBMapType implements DynamoDBType {
 
@@ -21,7 +21,7 @@ public class DynamoDBMapType implements DynamoDBType {
     System.out.println("values:");
     System.out.println(values);
     System.out.println("end values");
-    return new AttributeValue();//.withM(values[0]);
+    return AttributeValue.builder().build();
   }
 
   @Override

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/type/DynamoDBNullType.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/type/DynamoDBNullType.java
@@ -1,12 +1,12 @@
 package org.apache.hadoop.dynamodb.type;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import org.apache.hadoop.dynamodb.key.DynamoDBKey;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 public class DynamoDBNullType implements DynamoDBType {
   @Override
   public AttributeValue getAttributeValue(String... values) {
-    return new AttributeValue().withNULL(true);
+    return AttributeValue.fromNul(true);
   }
 
   @Override

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/type/DynamoDBNumberSetType.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/type/DynamoDBNumberSetType.java
@@ -13,14 +13,15 @@
 
 package org.apache.hadoop.dynamodb.type;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import java.util.Arrays;
 import org.apache.hadoop.dynamodb.key.DynamoDBKey;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 public class DynamoDBNumberSetType implements DynamoDBType {
 
   @Override
   public AttributeValue getAttributeValue(String... values) {
-    return new AttributeValue().withNS(values);
+    return AttributeValue.fromNs(Arrays.asList(values));
   }
 
   @Override

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/type/DynamoDBNumberType.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/type/DynamoDBNumberType.java
@@ -13,15 +13,15 @@
 
 package org.apache.hadoop.dynamodb.type;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import org.apache.hadoop.dynamodb.key.DynamoDBKey;
 import org.apache.hadoop.dynamodb.key.DynamoDBNumberKey;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 public class DynamoDBNumberType implements DynamoDBType {
 
   @Override
   public AttributeValue getAttributeValue(String... values) {
-    return new AttributeValue().withN(values[0]);
+    return AttributeValue.fromN(values[0]);
   }
 
   @Override

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/type/DynamoDBStringSetType.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/type/DynamoDBStringSetType.java
@@ -13,14 +13,15 @@
 
 package org.apache.hadoop.dynamodb.type;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import java.util.Arrays;
 import org.apache.hadoop.dynamodb.key.DynamoDBKey;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 public class DynamoDBStringSetType implements DynamoDBType {
 
   @Override
   public AttributeValue getAttributeValue(String... values) {
-    return new AttributeValue().withSS(values);
+    return AttributeValue.fromSs(Arrays.asList(values));
   }
 
   @Override

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/type/DynamoDBStringType.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/type/DynamoDBStringType.java
@@ -13,15 +13,15 @@
 
 package org.apache.hadoop.dynamodb.type;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import org.apache.hadoop.dynamodb.key.DynamoDBKey;
 import org.apache.hadoop.dynamodb.key.DynamoDBStringKey;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 public class DynamoDBStringType implements DynamoDBType {
 
   @Override
   public AttributeValue getAttributeValue(String... values) {
-    return new AttributeValue(values[0]);
+    return AttributeValue.fromS(values[0]);
   }
 
   @Override

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/type/DynamoDBType.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/type/DynamoDBType.java
@@ -13,8 +13,8 @@
 
 package org.apache.hadoop.dynamodb.type;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import org.apache.hadoop.dynamodb.key.DynamoDBKey;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 public interface DynamoDBType {
 

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/write/WriteIopsCalculator.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/write/WriteIopsCalculator.java
@@ -10,8 +10,6 @@
 
 package org.apache.hadoop.dynamodb.write;
 
-import com.amazonaws.services.dynamodbv2.model.ProvisionedThroughputDescription;
-import com.amazonaws.services.dynamodbv2.model.TableDescription;
 import com.google.common.base.Strings;
 import java.io.IOException;
 import org.apache.commons.logging.Log;
@@ -22,6 +20,9 @@ import org.apache.hadoop.dynamodb.DynamoDBUtil;
 import org.apache.hadoop.dynamodb.IopsCalculator;
 import org.apache.hadoop.mapred.JobClient;
 import org.apache.hadoop.mapred.JobConf;
+import software.amazon.awssdk.services.dynamodb.model.BillingMode;
+import software.amazon.awssdk.services.dynamodb.model.ProvisionedThroughputDescription;
+import software.amazon.awssdk.services.dynamodb.model.TableDescription;
 
 public class WriteIopsCalculator implements IopsCalculator {
 
@@ -89,11 +90,11 @@ public class WriteIopsCalculator implements IopsCalculator {
 
   private double getThroughput() {
     TableDescription tableDescription = dynamoDBClient.describeTable(tableName);
-    if (tableDescription.getBillingModeSummary() == null || tableDescription.getBillingModeSummary()
-        .getBillingMode().equalsIgnoreCase(DynamoDBConstants.BILLING_MODE_PROVISIONED)) {
+    if (tableDescription.billingModeSummary() == null
+            || tableDescription.billingModeSummary().billingMode() == BillingMode.PROVISIONED) {
       ProvisionedThroughputDescription provisionedThroughput =
-          tableDescription.getProvisionedThroughput();
-      return provisionedThroughput.getWriteCapacityUnits();
+          tableDescription.provisionedThroughput();
+      return provisionedThroughput.writeCapacityUnits();
     }
     return DynamoDBConstants.DEFAULT_CAPACITY_FOR_ON_DEMAND;
   }

--- a/emr-dynamodb-hadoop/src/test/java/org/apache/hadoop/dynamodb/DynamoDBItemWritableTest.java
+++ b/emr-dynamodb-hadoop/src/test/java/org/apache/hadoop/dynamodb/DynamoDBItemWritableTest.java
@@ -21,7 +21,6 @@ import static org.junit.Assert.assertNull;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 
-import org.apache.commons.io.IOUtils;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -61,12 +60,12 @@ public class DynamoDBItemWritableTest {
     item.write(out);
     outStream.close();
 
-    String data = outStream.toString();
+    final byte[] data = outStream.toByteArray();
 
     item.setItem(null);
     assertNull(item.getItem());
 
-    item.readFields(new DataInputStream(IOUtils.toInputStream(data)));
+    item.readFields(new DataInputStream(new ByteArrayInputStream(data)));
     checkReturnedItem();
   }
 

--- a/emr-dynamodb-hadoop/src/test/java/org/apache/hadoop/dynamodb/DynamoDBItemWritableTest.java
+++ b/emr-dynamodb-hadoop/src/test/java/org/apache/hadoop/dynamodb/DynamoDBItemWritableTest.java
@@ -21,8 +21,6 @@ import static org.junit.Assert.assertNull;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
-
 import org.apache.commons.io.IOUtils;
 import org.junit.Before;
 import org.junit.Test;
@@ -42,6 +40,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 public class DynamoDBItemWritableTest {
 
@@ -100,21 +100,21 @@ public class DynamoDBItemWritableTest {
     assertNotNull(item.getItem());
     Map<String, AttributeValue> returnedData = item.getItem();
     assertEquals(5, returnedData.size());
-    assertEquals("test", returnedData.get("s").getS());
-    assertEquals("1234", returnedData.get("n").getN());
-    assertNull(returnedData.get("n").getS());
-    assertEquals(0, returnedData.get("ss").getSS().size());
-    assertEquals(3, returnedData.get("ns").getNS().size());
-    assertEquals(2, returnedData.get("l").getL().size());
+    assertEquals("test", returnedData.get("s").s());
+    assertEquals("1234", returnedData.get("n").n());
+    assertNull(returnedData.get("n").s());
+    assertEquals(0, returnedData.get("ss").ss().size());
+    assertEquals(3, returnedData.get("ns").ns().size());
+    assertEquals(2, returnedData.get("l").l().size());
 
-    List<String> ns = returnedData.get("ns").getNS();
+    List<String> ns = returnedData.get("ns").ns();
     assertEquals("1.0", ns.get(0));
     assertEquals("1.10", ns.get(1));
     assertEquals("2.0", ns.get(2));
 
-    List<AttributeValue> l = returnedData.get("l").getL();
-    assertEquals("1.0", l.get(0).getS());
-    assertEquals("0", l.get(1).getS());
+    List<AttributeValue> l = returnedData.get("l").l();
+    assertEquals("1.0", l.get(0).s());
+    assertEquals("0", l.get(1).s());
   }
 
   @Test
@@ -137,10 +137,11 @@ public class DynamoDBItemWritableTest {
 
     for (int i = 0; i < loop; i++) {
       Map<String, AttributeValue> map = new HashMap<>();
-      map.put("hash", new AttributeValue().withB(byteBuffers.get(rnd.nextInt(totalByteArrays))));
-      map.put("range", new AttributeValue().withB(byteBuffers.get(rnd.nextInt(totalByteArrays))));
-      map.put("list", new AttributeValue().withBS(byteBuffers.get(rnd.nextInt(totalByteArrays)),
-          byteBuffers.get(rnd.nextInt(totalByteArrays))));
+      map.put("hash", AttributeValue.fromB(SdkBytes.fromByteBuffer(byteBuffers.get(rnd.nextInt(totalByteArrays)))));
+      map.put("range", AttributeValue.fromB(SdkBytes.fromByteBuffer(byteBuffers.get(rnd.nextInt(totalByteArrays)))));
+      map.put("list", AttributeValue.fromBs(Arrays.asList(
+          SdkBytes.fromByteBuffer(byteBuffers.get(rnd.nextInt(totalByteArrays))),
+          SdkBytes.fromByteBuffer(byteBuffers.get(rnd.nextInt(totalByteArrays))))));
 
       Map<String, AttributeValue> dynamoDBItem = gson.fromJson(gson.toJson(map, type), type);
       compare(map, dynamoDBItem);
@@ -156,9 +157,9 @@ public class DynamoDBItemWritableTest {
     item.readFieldsStream(malformedJson);
     Map<String, AttributeValue> attrValueMap = item.getItem();
 
-    assertEquals("seattle", attrValueMap.get("attr1").getS());
+    assertEquals("seattle", attrValueMap.get("attr1").s());
     assertEquals(new HashSet<>(Arrays.asList("123", "456", "789")), new HashSet<>(attrValueMap
-        .get("attr2").getNS()));
+        .get("attr2").ns()));
   }
 
   private void compare(Map<String, AttributeValue> map, Map<String, AttributeValue> map2) {
@@ -171,10 +172,10 @@ public class DynamoDBItemWritableTest {
     AttributeValue lList = map.get("list");
     AttributeValue rList = map.get("list");
 
-    assertArrayEquals(lHash.getB().array(), rHash.getB().array());
-    assertArrayEquals(lRange.getB().array(), rRange.getB().array());
-    assertArrayEquals(lList.getBS().get(0).array(), rList.getBS().get(0).array());
-    assertArrayEquals(lList.getBS().get(1).array(), rList.getBS().get(1).array());
+    assertArrayEquals(lHash.b().asByteArray(), rHash.b().asByteArray());
+    assertArrayEquals(lRange.b().asByteArray(), rRange.b().asByteArray());
+    assertArrayEquals(lList.bs().get(0).asByteArray(), rList.bs().get(0).asByteArray());
+    assertArrayEquals(lList.bs().get(1).asByteArray(), rList.bs().get(1).asByteArray());
   }
 
   private void setTestData() {
@@ -184,15 +185,15 @@ public class DynamoDBItemWritableTest {
     ns.add("1.10");
     ns.add("2.0");
     List<AttributeValue> l = new ArrayList<>();
-    l.add(new AttributeValue("1.0"));
-    l.add(new AttributeValue("0"));
+    l.add(AttributeValue.fromS("1.0"));
+    l.add(AttributeValue.fromS("0"));
 
     Map<String, AttributeValue> sampleData = new HashMap<>();
-    sampleData.put("s", new AttributeValue().withS("test"));
-    sampleData.put("n", new AttributeValue().withN("1234"));
-    sampleData.put("ss", new AttributeValue().withSS(ss));
-    sampleData.put("ns", new AttributeValue().withNS(ns));
-    sampleData.put("l", new AttributeValue().withL(l));
+    sampleData.put("s", AttributeValue.fromS("test"));
+    sampleData.put("n", AttributeValue.fromN("1234"));
+    sampleData.put("ss", AttributeValue.fromSs(ss));
+    sampleData.put("ns", AttributeValue.fromNs(ns));
+    sampleData.put("l", AttributeValue.fromL(l));
 
     item.setItem(sampleData);
   }

--- a/emr-dynamodb-hadoop/src/test/java/org/apache/hadoop/dynamodb/preader/ScanRecordReadRequestTest.java
+++ b/emr-dynamodb-hadoop/src/test/java/org/apache/hadoop/dynamodb/preader/ScanRecordReadRequestTest.java
@@ -7,9 +7,6 @@ import static org.mockito.Matchers.anyLong;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.when;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
-import com.amazonaws.services.dynamodbv2.model.ScanResult;
-
 import org.apache.hadoop.dynamodb.DynamoDBClient;
 import org.apache.hadoop.dynamodb.DynamoDBFibonacciRetryer.RetryResult;
 import org.apache.hadoop.dynamodb.filter.DynamoDBQueryFilter;
@@ -25,6 +22,9 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.HashMap;
 import java.util.Map;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.ConsumedCapacity;
+import software.amazon.awssdk.services.dynamodb.model.ScanResponse;
 
 @RunWith(MockitoJUnitRunner.class)
 public final class ScanRecordReadRequestTest {
@@ -36,8 +36,10 @@ public final class ScanRecordReadRequestTest {
 
   @Test
   public void fetchPageReturnsZeroConsumedCapacityWhenResultsConsumedCapacityIsNull() {
-    RetryResult stubbedResult = new RetryResult<>(new ScanResult().withConsumedCapacity(null)
-        .withItems(new HashMap<String, AttributeValue>()), 0);
+    RetryResult stubbedResult = new RetryResult<>(ScanResponse.builder()
+        .consumedCapacity((ConsumedCapacity) null)
+        .items(new HashMap<String, AttributeValue>())
+        .build(), 0);
     stubScanTableWith(stubbedResult);
 
     when(context.getClient()).thenReturn(client);
@@ -50,7 +52,7 @@ public final class ScanRecordReadRequestTest {
     assertEquals(0.0, pageResults.consumedRcu, 0.0);
   }
 
-  private void stubScanTableWith(RetryResult<ScanResult> scanResultRetryResult) {
+  private void stubScanTableWith(RetryResult<ScanResponse> scanResultRetryResult) {
     when(client.scanTable(
         anyString(),
         any(DynamoDBQueryFilter.class),

--- a/emr-dynamodb-hadoop/src/test/java/org/apache/hadoop/dynamodb/read/DynamoDBRecordReaderTest.java
+++ b/emr-dynamodb-hadoop/src/test/java/org/apache/hadoop/dynamodb/read/DynamoDBRecordReaderTest.java
@@ -28,7 +28,6 @@ import org.apache.hadoop.mapred.Counters.Counter;
 import org.apache.hadoop.mapred.InputSplit;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.Reporter;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -169,7 +168,6 @@ public class DynamoDBRecordReaderTest {
     }
   }
 
-  @Ignore
   @Test
   public void testConsumingAllBeginningElementsIfStartKeyIsNull() {
     DynamoDBSplit split = new DynamoDBSegmentsSplit(null, 0, 0, Arrays.asList(0), 4, 0, new

--- a/emr-dynamodb-hadoop/src/test/java/org/apache/hadoop/dynamodb/read/ReadIopsCalculatorTest.java
+++ b/emr-dynamodb-hadoop/src/test/java/org/apache/hadoop/dynamodb/read/ReadIopsCalculatorTest.java
@@ -15,11 +15,6 @@ package org.apache.hadoop.dynamodb.read;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
-
-import com.amazonaws.services.dynamodbv2.model.BillingModeSummary;
-import com.amazonaws.services.dynamodbv2.model.ProvisionedThroughputDescription;
-import com.amazonaws.services.dynamodbv2.model.TableDescription;
-
 import org.apache.hadoop.dynamodb.DynamoDBClient;
 import org.apache.hadoop.dynamodb.DynamoDBConstants;
 import org.apache.hadoop.mapred.JobClient;
@@ -29,6 +24,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+import software.amazon.awssdk.services.dynamodb.model.BillingModeSummary;
+import software.amazon.awssdk.services.dynamodb.model.ProvisionedThroughputDescription;
+import software.amazon.awssdk.services.dynamodb.model.TableDescription;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ReadIopsCalculatorTest {
@@ -47,11 +45,14 @@ public class ReadIopsCalculatorTest {
 
   @Before
   public void setup() {
-    when(dynamoDBClient.describeTable(TABLE_NAME)).thenReturn(new TableDescription()
-        .withBillingModeSummary(
-            new BillingModeSummary().withBillingMode(DynamoDBConstants.BILLING_MODE_PROVISIONED))
-        .withProvisionedThroughput(
-            new ProvisionedThroughputDescription().withReadCapacityUnits(READ_CAPACITY_UNITS)));
+    when(dynamoDBClient.describeTable(TABLE_NAME)).thenReturn(TableDescription.builder()
+        .billingModeSummary(BillingModeSummary.builder()
+            .billingMode(DynamoDBConstants.BILLING_MODE_PROVISIONED)
+            .build())
+        .provisionedThroughput(ProvisionedThroughputDescription.builder()
+            .readCapacityUnits(READ_CAPACITY_UNITS)
+            .build())
+        .build());
 
     JobConf jobConf = new JobConf();
     jobConf.set(DynamoDBConstants.THROUGHPUT_READ_PERCENT, String.valueOf(THROUGHPUT_READ_PERCENT));

--- a/emr-dynamodb-hadoop/src/test/java/org/apache/hadoop/dynamodb/test/DynamoDBTestUtils.java
+++ b/emr-dynamodb-hadoop/src/test/java/org/apache/hadoop/dynamodb/test/DynamoDBTestUtils.java
@@ -13,17 +13,15 @@
 
 package org.apache.hadoop.dynamodb.test;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.dynamodb.type.DynamoDBTypeConstants;
 import com.google.common.collect.Lists;
 
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Random;
+import java.util.*;
+import java.util.stream.Collectors;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 import static org.junit.Assert.assertEquals;
 
@@ -103,13 +101,15 @@ public class DynamoDBTestUtils {
 
   public static Map<String, AttributeValue> getRandomItem() {
     Map<String, AttributeValue> item = new HashMap<>();
-    item.put(DynamoDBTypeConstants.STRING, new AttributeValue().withS(getRandomString()));
-    item.put(DynamoDBTypeConstants.STRING_SET, new AttributeValue().withSS(getRandomStrings()));
-    item.put(DynamoDBTypeConstants.NUMBER, new AttributeValue().withN(getRandomNumber()));
-    item.put(DynamoDBTypeConstants.LIST, new AttributeValue().withL(new AttributeValue().withM(aRandomMap)));
-    item.put(DynamoDBTypeConstants.NUMBER_SET, new AttributeValue().withNS(getRandomNumbers()));
-    item.put(DynamoDBTypeConstants.BINARY, new AttributeValue().withB(getRandomByteBuffer()));
-    item.put(DynamoDBTypeConstants.BINARY_SET, new AttributeValue().withBS(getRandomByteBuffers()));
+    item.put(DynamoDBTypeConstants.STRING, AttributeValue.fromS(getRandomString()));
+    item.put(DynamoDBTypeConstants.STRING_SET, AttributeValue.fromSs(getRandomStrings()));
+    item.put(DynamoDBTypeConstants.NUMBER, AttributeValue.fromN(getRandomNumber()));
+    item.put(DynamoDBTypeConstants.LIST, AttributeValue.fromL(Arrays.asList(AttributeValue.fromM(aRandomMap))));
+    item.put(DynamoDBTypeConstants.NUMBER_SET, AttributeValue.fromNs(getRandomNumbers()));
+    item.put(DynamoDBTypeConstants.BINARY, AttributeValue.fromB(SdkBytes.fromByteBuffer(getRandomByteBuffer())));
+    item.put(DynamoDBTypeConstants.BINARY_SET, AttributeValue.fromBs(getRandomByteBuffers().stream()
+        .map(byteBuffer -> SdkBytes.fromByteBuffer(byteBuffer))
+        .collect(Collectors.toList())));
     return item;
   }
 

--- a/emr-dynamodb-hadoop/src/test/java/org/apache/hadoop/dynamodb/test/GsonTest.java
+++ b/emr-dynamodb-hadoop/src/test/java/org/apache/hadoop/dynamodb/test/GsonTest.java
@@ -17,8 +17,6 @@ import static org.junit.Assert.assertFalse;
 
 import com.google.gson.Gson;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
-
 import org.apache.hadoop.dynamodb.DynamoDBItemWritable;
 import org.apache.hadoop.dynamodb.DynamoDBUtil;
 import org.junit.Test;
@@ -28,6 +26,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 public class GsonTest {
   private static final int TASK_COUNT = 100;
@@ -44,7 +43,7 @@ public class GsonTest {
   @Test
   public void testSpecialCase1() {
     Map<String, AttributeValue> item = DynamoDBTestUtils.getRandomItem();
-    item.put("S", new AttributeValue().withS("This is a \n \0 \1 \2 line test"));
+    item.put("S", AttributeValue.fromS("This is a \n \0 \1 \2 line test"));
 
     Gson gson = DynamoDBUtil.getGson();
     String json = gson.toJson(item, DynamoDBItemWritable.type);

--- a/emr-dynamodb-hadoop/src/test/java/org/apache/hadoop/dynamodb/write/WriteIopsCalculatorTest.java
+++ b/emr-dynamodb-hadoop/src/test/java/org/apache/hadoop/dynamodb/write/WriteIopsCalculatorTest.java
@@ -16,10 +16,6 @@ package org.apache.hadoop.dynamodb.write;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
 
-import com.amazonaws.services.dynamodbv2.model.BillingModeSummary;
-import com.amazonaws.services.dynamodbv2.model.ProvisionedThroughputDescription;
-import com.amazonaws.services.dynamodbv2.model.TableDescription;
-
 import org.apache.hadoop.dynamodb.DynamoDBClient;
 import org.apache.hadoop.dynamodb.DynamoDBConstants;
 import org.apache.hadoop.mapred.JobClient;
@@ -29,6 +25,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+import software.amazon.awssdk.services.dynamodb.model.BillingMode;
+import software.amazon.awssdk.services.dynamodb.model.BillingModeSummary;
+import software.amazon.awssdk.services.dynamodb.model.ProvisionedThroughputDescription;
+import software.amazon.awssdk.services.dynamodb.model.TableDescription;
 
 @RunWith(MockitoJUnitRunner.class)
 public class WriteIopsCalculatorTest {
@@ -47,11 +47,16 @@ public class WriteIopsCalculatorTest {
 
   @Before
   public void setup() {
-    when(dynamoDBClient.describeTable(TABLE_NAME)).thenReturn(new TableDescription()
-        .withBillingModeSummary(
-            new BillingModeSummary().withBillingMode(DynamoDBConstants.BILLING_MODE_PROVISIONED))
-        .withProvisionedThroughput(
-            new ProvisionedThroughputDescription().withWriteCapacityUnits(WRITE_CAPACITY_UNITS)));
+    when(dynamoDBClient.describeTable(TABLE_NAME)).thenReturn(TableDescription.builder()
+        .billingModeSummary(
+            BillingModeSummary.builder()
+                .billingMode(BillingMode.PROVISIONED)
+                .build())
+        .provisionedThroughput(
+            ProvisionedThroughputDescription.builder()
+                .writeCapacityUnits(WRITE_CAPACITY_UNITS)
+                .build())
+        .build());
 
     JobConf jobConf = new JobConf();
     jobConf.setNumMapTasks(TOTAL_MAP_TASKS);

--- a/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/DynamoDBExportSerDe.java
+++ b/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/DynamoDBExportSerDe.java
@@ -13,7 +13,6 @@
 
 package org.apache.hadoop.hive.dynamodb;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import com.google.common.base.Strings;
 import com.google.common.collect.Maps;
 import java.util.Arrays;
@@ -27,6 +26,7 @@ import org.apache.hadoop.hive.serde2.SerDeException;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.Writable;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
  * This class is used to read the DynamoDB backup format and allow querying individual columns from

--- a/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/DynamoDBObjectInspector.java
+++ b/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/DynamoDBObjectInspector.java
@@ -13,7 +13,6 @@
 
 package org.apache.hadoop.hive.dynamodb;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import java.util.ArrayList;
@@ -29,6 +28,7 @@ import org.apache.hadoop.hive.serde2.objectinspector.StructField;
 import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 public class DynamoDBObjectInspector extends StructObjectInspector {
 

--- a/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/filter/AbstractDynamoDBFilter.java
+++ b/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/filter/AbstractDynamoDBFilter.java
@@ -13,9 +13,9 @@
 
 package org.apache.hadoop.hive.dynamodb.filter;
 
-import com.amazonaws.services.dynamodbv2.model.Condition;
 import org.apache.hadoop.dynamodb.filter.DynamoDBFilter;
 import org.apache.hadoop.dynamodb.filter.DynamoDBFilterOperator;
+import software.amazon.awssdk.services.dynamodb.model.Condition;
 
 public abstract class AbstractDynamoDBFilter implements DynamoDBFilter {
 

--- a/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/filter/DynamoDBBinaryFilter.java
+++ b/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/filter/DynamoDBBinaryFilter.java
@@ -13,12 +13,12 @@
 
 package org.apache.hadoop.hive.dynamodb.filter;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
-import com.amazonaws.services.dynamodbv2.model.Condition;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.hadoop.dynamodb.filter.DynamoDBFilterOperator;
 import org.apache.hadoop.hive.dynamodb.type.HiveDynamoDBTypeFactory;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.Condition;
 
 public class DynamoDBBinaryFilter extends AbstractDynamoDBFilter {
 
@@ -33,12 +33,14 @@ public class DynamoDBBinaryFilter extends AbstractDynamoDBFilter {
 
   @Override
   public Condition createCondition() {
-    Condition condition = new Condition();
-    condition.setComparisonOperator(operator.getDynamoDBName());
     List<AttributeValue> attributeValueList = new ArrayList<AttributeValue>();
     attributeValueList.add(HiveDynamoDBTypeFactory.getTypeObjectFromHiveType(columnType)
         .getAttributeValue(columnValue));
-    condition.setAttributeValueList(attributeValueList);
+
+    Condition condition = Condition.builder()
+        .comparisonOperator(operator.getDynamoDBName())
+        .attributeValueList(attributeValueList)
+        .build();
     return condition;
   }
 

--- a/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/filter/DynamoDBFilterPushdown.java
+++ b/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/filter/DynamoDBFilterPushdown.java
@@ -35,6 +35,7 @@ import org.apache.hadoop.hive.ql.plan.ExprNodeGenericFuncDesc;
 import org.apache.hadoop.hive.serde.serdeConstants;
 import software.amazon.awssdk.services.dynamodb.model.GlobalSecondaryIndexDescription;
 import software.amazon.awssdk.services.dynamodb.model.KeySchemaElement;
+import software.amazon.awssdk.services.dynamodb.model.KeyType;
 import software.amazon.awssdk.services.dynamodb.model.LocalSecondaryIndexDescription;
 import software.amazon.awssdk.services.dynamodb.model.Projection;
 import software.amazon.awssdk.services.dynamodb.model.ProjectionType;
@@ -329,7 +330,7 @@ public class DynamoDBFilterPushdown {
   private boolean indexIncludesAllMappedAttributes(List<KeySchemaElement> tableSchema,
       DynamoDBIndexInfo index, Map<String, String> hiveDynamoDBMapping) {
     Projection indexProjection = index.getIndexProjection();
-    if (ProjectionType.ALL.toString().equals(indexProjection.projectionType())) {
+    if (ProjectionType.ALL == indexProjection.projectionType()) {
       return true;
     }
 
@@ -340,7 +341,7 @@ public class DynamoDBFilterPushdown {
     for (KeySchemaElement keySchemaElement: index.getIndexSchema()) {
       projectionAttributes.add(keySchemaElement.attributeName());
     }
-    if (ProjectionType.INCLUDE.toString().equals(indexProjection.projectionType())) {
+    if (ProjectionType.INCLUDE == indexProjection.projectionType()) {
       projectionAttributes.addAll(indexProjection.nonKeyAttributes());
     }
 
@@ -363,7 +364,7 @@ public class DynamoDBFilterPushdown {
 
     boolean hashKeyFilterExists = false;
     if (schema.size() > 0
-        && DYNAMODB_KEY_TYPE_HASH.equals(schema.get(HASH_KEY_INDEX).keyType())) {
+        && KeyType.HASH == schema.get(HASH_KEY_INDEX).keyType()) {
       String hashKeyName = schema.get(HASH_KEY_INDEX).attributeName();
       if (filterMap.containsKey(hashKeyName)) {
         DynamoDBFilter hashKeyFilter = filterMap.get(hashKeyName);

--- a/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/filter/DynamoDBFilterPushdown.java
+++ b/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/filter/DynamoDBFilterPushdown.java
@@ -13,11 +13,6 @@
 
 package org.apache.hadoop.hive.dynamodb.filter;
 
-import com.amazonaws.services.dynamodbv2.model.GlobalSecondaryIndexDescription;
-import com.amazonaws.services.dynamodbv2.model.KeySchemaElement;
-import com.amazonaws.services.dynamodbv2.model.LocalSecondaryIndexDescription;
-import com.amazonaws.services.dynamodbv2.model.Projection;
-import com.amazonaws.services.dynamodbv2.model.ProjectionType;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -38,6 +33,11 @@ import org.apache.hadoop.hive.ql.metadata.HiveStoragePredicateHandler.Decomposed
 import org.apache.hadoop.hive.ql.plan.ExprNodeDesc;
 import org.apache.hadoop.hive.ql.plan.ExprNodeGenericFuncDesc;
 import org.apache.hadoop.hive.serde.serdeConstants;
+import software.amazon.awssdk.services.dynamodb.model.GlobalSecondaryIndexDescription;
+import software.amazon.awssdk.services.dynamodb.model.KeySchemaElement;
+import software.amazon.awssdk.services.dynamodb.model.LocalSecondaryIndexDescription;
+import software.amazon.awssdk.services.dynamodb.model.Projection;
+import software.amazon.awssdk.services.dynamodb.model.ProjectionType;
 
 public class DynamoDBFilterPushdown {
 
@@ -256,8 +256,8 @@ public class DynamoDBFilterPushdown {
         indexUseForQuery = getIndexUseForQuery(
             schema,
             globalSecondaryIndexes.stream()
-                .map(index -> new DynamoDBIndexInfo(index.getIndexName(),
-                    index.getKeySchema(), index.getProjection()))
+                .map(index -> new DynamoDBIndexInfo(index.indexName(),
+                    index.keySchema(), index.projection()))
                 .collect(Collectors.toList()),
             hiveDynamoDBMapping,
             filterMap,
@@ -275,8 +275,8 @@ public class DynamoDBFilterPushdown {
         indexUseForQuery = getIndexUseForQuery(
             schema,
             localSecondaryIndexes.stream()
-                .map(index -> new DynamoDBIndexInfo(index.getIndexName(),
-                    index.getKeySchema(), index.getProjection()))
+                .map(index -> new DynamoDBIndexInfo(index.indexName(),
+                    index.keySchema(), index.projection()))
                 .collect(Collectors.toList()),
             hiveDynamoDBMapping,
             filterMap,
@@ -329,19 +329,19 @@ public class DynamoDBFilterPushdown {
   private boolean indexIncludesAllMappedAttributes(List<KeySchemaElement> tableSchema,
       DynamoDBIndexInfo index, Map<String, String> hiveDynamoDBMapping) {
     Projection indexProjection = index.getIndexProjection();
-    if (ProjectionType.ALL.toString().equals(indexProjection.getProjectionType())) {
+    if (ProjectionType.ALL.toString().equals(indexProjection.projectionType())) {
       return true;
     }
 
     Set<String> projectionAttributes = new HashSet<>();
     for (KeySchemaElement keySchemaElement: tableSchema) {
-      projectionAttributes.add(keySchemaElement.getAttributeName());
+      projectionAttributes.add(keySchemaElement.attributeName());
     }
     for (KeySchemaElement keySchemaElement: index.getIndexSchema()) {
-      projectionAttributes.add(keySchemaElement.getAttributeName());
+      projectionAttributes.add(keySchemaElement.attributeName());
     }
-    if (ProjectionType.INCLUDE.toString().equals(indexProjection.getProjectionType())) {
-      projectionAttributes.addAll(indexProjection.getNonKeyAttributes());
+    if (ProjectionType.INCLUDE.toString().equals(indexProjection.projectionType())) {
+      projectionAttributes.addAll(indexProjection.nonKeyAttributes());
     }
 
     log.info("Checking if all mapped attributes " + hiveDynamoDBMapping.values()
@@ -363,8 +363,8 @@ public class DynamoDBFilterPushdown {
 
     boolean hashKeyFilterExists = false;
     if (schema.size() > 0
-        && DYNAMODB_KEY_TYPE_HASH.equals(schema.get(HASH_KEY_INDEX).getKeyType())) {
-      String hashKeyName = schema.get(HASH_KEY_INDEX).getAttributeName();
+        && DYNAMODB_KEY_TYPE_HASH.equals(schema.get(HASH_KEY_INDEX).keyType())) {
+      String hashKeyName = schema.get(HASH_KEY_INDEX).attributeName();
       if (filterMap.containsKey(hashKeyName)) {
         DynamoDBFilter hashKeyFilter = filterMap.get(hashKeyName);
         if (DynamoDBFilterOperator.EQ.equals(hashKeyFilter.getOperator())) {
@@ -375,7 +375,7 @@ public class DynamoDBFilterPushdown {
     }
 
     if (hashKeyFilterExists && schema.size() > 1) {
-      String rangeKeyName = schema.get(RANGE_KEY_INDEX).getAttributeName();
+      String rangeKeyName = schema.get(RANGE_KEY_INDEX).attributeName();
       if (filterMap.containsKey(rangeKeyName)) {
         DynamoDBFilter rangeKeyFilter = filterMap.get(rangeKeyName);
         if (eligibleOperatorsForRange.contains(rangeKeyFilter.getOperator())) {

--- a/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/filter/DynamoDBNAryFilter.java
+++ b/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/filter/DynamoDBNAryFilter.java
@@ -13,12 +13,12 @@
 
 package org.apache.hadoop.hive.dynamodb.filter;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
-import com.amazonaws.services.dynamodbv2.model.Condition;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.hadoop.dynamodb.filter.DynamoDBFilterOperator;
 import org.apache.hadoop.hive.dynamodb.type.HiveDynamoDBTypeFactory;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.Condition;
 
 public class DynamoDBNAryFilter extends AbstractDynamoDBFilter {
 
@@ -32,16 +32,16 @@ public class DynamoDBNAryFilter extends AbstractDynamoDBFilter {
 
   @Override
   public Condition createCondition() {
-    Condition condition = new Condition();
-    condition.setComparisonOperator(operator.getDynamoDBName());
-
     List<AttributeValue> attributeValueList = new ArrayList<>();
     for (String value : columnValues) {
       attributeValueList.add(HiveDynamoDBTypeFactory.getTypeObjectFromHiveType(columnType)
           .getAttributeValue(value));
     }
-    condition.setAttributeValueList(attributeValueList);
 
+    Condition condition = Condition.builder()
+        .comparisonOperator(operator.getDynamoDBName())
+        .attributeValueList(attributeValueList)
+        .build();
     return condition;
   }
 }

--- a/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/filter/DynamoDBUnaryFilter.java
+++ b/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/filter/DynamoDBUnaryFilter.java
@@ -13,8 +13,8 @@
 
 package org.apache.hadoop.hive.dynamodb.filter;
 
-import com.amazonaws.services.dynamodbv2.model.Condition;
 import org.apache.hadoop.dynamodb.filter.DynamoDBFilterOperator;
+import software.amazon.awssdk.services.dynamodb.model.Condition;
 
 public class DynamoDBUnaryFilter extends AbstractDynamoDBFilter {
 
@@ -25,8 +25,9 @@ public class DynamoDBUnaryFilter extends AbstractDynamoDBFilter {
 
   @Override
   public Condition createCondition() {
-    Condition condition = new Condition();
-    condition.setComparisonOperator(operator.getDynamoDBName());
+    Condition condition = Condition.builder()
+        .comparisonOperator(operator.getDynamoDBName())
+        .build();
     return condition;
   }
 

--- a/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/read/HiveDynamoDBInputFormat.java
+++ b/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/read/HiveDynamoDBInputFormat.java
@@ -13,7 +13,6 @@
 
 package org.apache.hadoop.hive.dynamodb.read;
 
-import com.amazonaws.services.dynamodbv2.model.TableDescription;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
@@ -41,6 +40,7 @@ import org.apache.hadoop.mapred.InputSplit;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.RecordReader;
 import org.apache.hadoop.mapred.Reporter;
+import software.amazon.awssdk.services.dynamodb.model.TableDescription;
 
 public class HiveDynamoDBInputFormat extends DynamoDBInputFormat {
 
@@ -152,9 +152,9 @@ public class HiveDynamoDBInputFormat extends DynamoDBInputFormat {
     TableDescription tableDescription =
         client.describeTable(conf.get(DynamoDBConstants.TABLE_NAME));
     DynamoDBQueryFilter queryFilter = pushdown.predicateToDynamoDBFilter(
-        tableDescription.getKeySchema(),
-        tableDescription.getLocalSecondaryIndexes(),
-        tableDescription.getGlobalSecondaryIndexes(),
+        tableDescription.keySchema(),
+        tableDescription.localSecondaryIndexes(),
+        tableDescription.globalSecondaryIndexes(),
         hiveDynamoDBMapping, hiveTypeMapping, filterExpr);
     return queryFilter;
   }

--- a/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/type/HiveDynamoDBBinaryType.java
+++ b/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/type/HiveDynamoDBBinaryType.java
@@ -13,13 +13,14 @@
 
 package org.apache.hadoop.hive.dynamodb.type;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import java.nio.ByteBuffer;
 import org.apache.hadoop.dynamodb.type.DynamoDBBinaryType;
 import org.apache.hadoop.hive.dynamodb.util.DynamoDBDataParser;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 public class HiveDynamoDBBinaryType extends DynamoDBBinaryType implements HiveDynamoDBType {
 
@@ -29,7 +30,7 @@ public class HiveDynamoDBBinaryType extends DynamoDBBinaryType implements HiveDy
     ByteBuffer value = DynamoDBDataParser.getByteBuffer(data, objectInspector);
     return value == null
         ? DynamoDBDataParser.getNullAttribute(nullSerialization)
-        : new AttributeValue().withB(value);
+        : AttributeValue.fromB(SdkBytes.fromByteBuffer(value));
   }
 
   @Override
@@ -44,6 +45,6 @@ public class HiveDynamoDBBinaryType extends DynamoDBBinaryType implements HiveDy
 
   @Override
   public Object getHiveData(AttributeValue data, ObjectInspector objectInspector) {
-    return data.getB() == null ? null : data.getB().array();
+    return data.b() == null ? null : data.b().asByteArray();
   }
 }

--- a/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/type/HiveDynamoDBBooleanType.java
+++ b/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/type/HiveDynamoDBBooleanType.java
@@ -1,11 +1,11 @@
 package org.apache.hadoop.hive.dynamodb.type;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import org.apache.hadoop.dynamodb.type.DynamoDBBooleanType;
 import org.apache.hadoop.hive.dynamodb.util.DynamoDBDataParser;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 public class HiveDynamoDBBooleanType extends DynamoDBBooleanType implements HiveDynamoDBType {
 
@@ -15,7 +15,7 @@ public class HiveDynamoDBBooleanType extends DynamoDBBooleanType implements Hive
     Boolean value = DynamoDBDataParser.getBoolean(data, objectInspector);
     return value == null
         ? DynamoDBDataParser.getNullAttribute(nullSerialization)
-        : new AttributeValue().withBOOL(value);
+        : AttributeValue.fromBool(value);
   }
 
   @Override
@@ -30,6 +30,6 @@ public class HiveDynamoDBBooleanType extends DynamoDBBooleanType implements Hive
 
   @Override
   public Object getHiveData(AttributeValue data, ObjectInspector objectInspector) {
-    return data.getBOOL();
+    return data.bool();
   }
 }

--- a/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/type/HiveDynamoDBItemType.java
+++ b/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/type/HiveDynamoDBItemType.java
@@ -13,7 +13,6 @@
 
 package org.apache.hadoop.hive.dynamodb.type;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import java.lang.reflect.Type;
@@ -30,6 +29,7 @@ import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.StringObjectInspector;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 public class HiveDynamoDBItemType implements DynamoDBItemType, HiveDynamoDBType {
 

--- a/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/type/HiveDynamoDBListType.java
+++ b/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/type/HiveDynamoDBListType.java
@@ -11,13 +11,13 @@
 
 package org.apache.hadoop.hive.dynamodb.type;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import java.util.List;
 import org.apache.hadoop.dynamodb.type.DynamoDBListType;
 import org.apache.hadoop.hive.dynamodb.util.DynamoDBDataParser;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.typeinfo.ListTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 public class HiveDynamoDBListType extends DynamoDBListType implements HiveDynamoDBType {
 
@@ -28,7 +28,7 @@ public class HiveDynamoDBListType extends DynamoDBListType implements HiveDynamo
         DynamoDBDataParser.getListAttribute(data, objectInspector, nullSerialization);
     return values == null
         ? DynamoDBDataParser.getNullAttribute(nullSerialization)
-        : new AttributeValue().withL(values);
+        : AttributeValue.fromL(values);
   }
 
   @Override
@@ -54,8 +54,8 @@ public class HiveDynamoDBListType extends DynamoDBListType implements HiveDynamo
 
   @Override
   public Object getHiveData(AttributeValue data, ObjectInspector objectInspector) {
-    return data.getL() == null ? null
-        : DynamoDBDataParser.getListObject(data.getL(), objectInspector);
+    return data.l() == null ? null
+        : DynamoDBDataParser.getListObject(data.l(), objectInspector);
   }
 
 }

--- a/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/type/HiveDynamoDBListType.java
+++ b/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/type/HiveDynamoDBListType.java
@@ -54,8 +54,8 @@ public class HiveDynamoDBListType extends DynamoDBListType implements HiveDynamo
 
   @Override
   public Object getHiveData(AttributeValue data, ObjectInspector objectInspector) {
-    return data.l() == null ? null
-        : DynamoDBDataParser.getListObject(data.l(), objectInspector);
+    return data.hasL() ? DynamoDBDataParser.getListObject(data.l(), objectInspector)
+        : null;
   }
 
 }

--- a/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/type/HiveDynamoDBMapType.java
+++ b/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/type/HiveDynamoDBMapType.java
@@ -11,7 +11,6 @@
 
 package org.apache.hadoop.hive.dynamodb.type;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import java.util.Map;
 import org.apache.hadoop.dynamodb.type.DynamoDBMapType;
 import org.apache.hadoop.hive.dynamodb.util.DynamoDBDataParser;
@@ -20,6 +19,7 @@ import org.apache.hadoop.hive.serde2.typeinfo.MapTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.StructTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 public class HiveDynamoDBMapType extends DynamoDBMapType implements HiveDynamoDBType {
 
@@ -30,7 +30,7 @@ public class HiveDynamoDBMapType extends DynamoDBMapType implements HiveDynamoDB
         DynamoDBDataParser.getMapAttribute(data, objectInspector, nullSerialization);
     return values == null
         ? DynamoDBDataParser.getNullAttribute(nullSerialization)
-        : new AttributeValue().withM(values);
+        : AttributeValue.fromM(values);
   }
 
   @Override
@@ -70,7 +70,7 @@ public class HiveDynamoDBMapType extends DynamoDBMapType implements HiveDynamoDB
 
   @Override
   public Object getHiveData(AttributeValue data, ObjectInspector objectInspector) {
-    Map<String, AttributeValue> dataMap = data.getM();
+    Map<String, AttributeValue> dataMap = data.m();
     if (dataMap == null) {
       return null;
     }

--- a/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/type/HiveDynamoDBMapType.java
+++ b/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/type/HiveDynamoDBMapType.java
@@ -70,10 +70,11 @@ public class HiveDynamoDBMapType extends DynamoDBMapType implements HiveDynamoDB
 
   @Override
   public Object getHiveData(AttributeValue data, ObjectInspector objectInspector) {
-    Map<String, AttributeValue> dataMap = data.m();
-    if (dataMap == null) {
+    if (!data.hasM()) {
       return null;
     }
+
+    Map<String, AttributeValue> dataMap = data.m();
     switch (objectInspector.getCategory()) {
       case MAP:
         return DynamoDBDataParser.getMapObject(dataMap, objectInspector);

--- a/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/type/HiveDynamoDBNullType.java
+++ b/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/type/HiveDynamoDBNullType.java
@@ -1,11 +1,11 @@
 package org.apache.hadoop.hive.dynamodb.type;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import org.apache.hadoop.dynamodb.type.DynamoDBNullType;
 import org.apache.hadoop.hive.dynamodb.util.DynamoDBDataParser;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 public class HiveDynamoDBNullType extends DynamoDBNullType implements HiveDynamoDBType {
 

--- a/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/type/HiveDynamoDBNumberSetType.java
+++ b/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/type/HiveDynamoDBNumberSetType.java
@@ -13,13 +13,13 @@
 
 package org.apache.hadoop.hive.dynamodb.type;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import java.util.List;
 import org.apache.hadoop.dynamodb.type.DynamoDBNumberSetType;
 import org.apache.hadoop.hive.dynamodb.util.DynamoDBDataParser;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 public class HiveDynamoDBNumberSetType extends DynamoDBNumberSetType implements HiveDynamoDBType {
 
@@ -30,7 +30,7 @@ public class HiveDynamoDBNumberSetType extends DynamoDBNumberSetType implements 
         getDynamoDBType());
     return (values == null || values.isEmpty())
         ? DynamoDBDataParser.getNullAttribute(nullSerialization)
-        : new AttributeValue().withNS(values);
+        : AttributeValue.fromNs(values);
   }
 
   @Override
@@ -48,8 +48,8 @@ public class HiveDynamoDBNumberSetType extends DynamoDBNumberSetType implements 
 
   @Override
   public Object getHiveData(AttributeValue data, ObjectInspector objectInspector) {
-    return data.getNS() == null ? null
-        : DynamoDBDataParser.getNumberObjectList(data.getNS(), objectInspector);
+    return data.ns() == null ? null
+        : DynamoDBDataParser.getNumberObjectList(data.ns(), objectInspector);
   }
 
 }

--- a/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/type/HiveDynamoDBNumberSetType.java
+++ b/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/type/HiveDynamoDBNumberSetType.java
@@ -48,8 +48,8 @@ public class HiveDynamoDBNumberSetType extends DynamoDBNumberSetType implements 
 
   @Override
   public Object getHiveData(AttributeValue data, ObjectInspector objectInspector) {
-    return data.ns() == null ? null
-        : DynamoDBDataParser.getNumberObjectList(data.ns(), objectInspector);
+    return data.hasNs() ? DynamoDBDataParser.getNumberObjectList(data.ns(), objectInspector)
+        : null;
   }
 
 }

--- a/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/type/HiveDynamoDBNumberType.java
+++ b/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/type/HiveDynamoDBNumberType.java
@@ -13,12 +13,12 @@
 
 package org.apache.hadoop.hive.dynamodb.type;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import org.apache.hadoop.dynamodb.type.DynamoDBNumberType;
 import org.apache.hadoop.hive.dynamodb.util.DynamoDBDataParser;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 public class HiveDynamoDBNumberType extends DynamoDBNumberType implements HiveDynamoDBType {
 
@@ -28,7 +28,7 @@ public class HiveDynamoDBNumberType extends DynamoDBNumberType implements HiveDy
     String value = DynamoDBDataParser.getNumber(data, objectInspector);
     return value == null
         ? DynamoDBDataParser.getNullAttribute(nullSerialization)
-        : new AttributeValue().withN(value);
+        : AttributeValue.fromN(value);
   }
 
   @Override
@@ -45,8 +45,8 @@ public class HiveDynamoDBNumberType extends DynamoDBNumberType implements HiveDy
 
   @Override
   public Object getHiveData(AttributeValue data, ObjectInspector objectInspector) {
-    return data.getN() == null ? null
-        : DynamoDBDataParser.getNumberObject(data.getN(), objectInspector);
+    return data.n() == null ? null
+        : DynamoDBDataParser.getNumberObject(data.n(), objectInspector);
   }
 
 }

--- a/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/type/HiveDynamoDBStringSetType.java
+++ b/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/type/HiveDynamoDBStringSetType.java
@@ -13,13 +13,13 @@
 
 package org.apache.hadoop.hive.dynamodb.type;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import java.util.List;
 import org.apache.hadoop.dynamodb.type.DynamoDBStringSetType;
 import org.apache.hadoop.hive.dynamodb.util.DynamoDBDataParser;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 public class HiveDynamoDBStringSetType extends DynamoDBStringSetType implements HiveDynamoDBType {
 
@@ -30,7 +30,7 @@ public class HiveDynamoDBStringSetType extends DynamoDBStringSetType implements 
         DynamoDBDataParser.getSetAttribute(data, objectInspector, getDynamoDBType());
     return (values == null || values.isEmpty())
         ? DynamoDBDataParser.getNullAttribute(nullSerialization)
-        : new AttributeValue().withSS(values);
+        : AttributeValue.fromSs(values);
   }
 
   @Override
@@ -45,7 +45,7 @@ public class HiveDynamoDBStringSetType extends DynamoDBStringSetType implements 
 
   @Override
   public Object getHiveData(AttributeValue data, ObjectInspector objectInspector) {
-    return data.getSS();
+    return data.ss();
   }
 
 }

--- a/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/type/HiveDynamoDBStringType.java
+++ b/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/type/HiveDynamoDBStringType.java
@@ -13,12 +13,12 @@
 
 package org.apache.hadoop.hive.dynamodb.type;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import org.apache.hadoop.dynamodb.type.DynamoDBStringType;
 import org.apache.hadoop.hive.dynamodb.util.DynamoDBDataParser;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 public class HiveDynamoDBStringType extends DynamoDBStringType implements HiveDynamoDBType {
   @Override
@@ -27,7 +27,7 @@ public class HiveDynamoDBStringType extends DynamoDBStringType implements HiveDy
     String value = DynamoDBDataParser.getString(data, objectInspector);
     return value == null
         ? DynamoDBDataParser.getNullAttribute(nullSerialization)
-        : new AttributeValue(value);
+        : AttributeValue.fromS(value);
   }
 
   @Override
@@ -42,7 +42,7 @@ public class HiveDynamoDBStringType extends DynamoDBStringType implements HiveDy
 
   @Override
   public Object getHiveData(AttributeValue data, ObjectInspector objectInspector) {
-    return data.getS();
+    return data.s();
   }
 
 }

--- a/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/type/HiveDynamoDBType.java
+++ b/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/type/HiveDynamoDBType.java
@@ -13,10 +13,10 @@
 
 package org.apache.hadoop.hive.dynamodb.type;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import org.apache.hadoop.dynamodb.type.DynamoDBType;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 public interface HiveDynamoDBType extends DynamoDBType {
 

--- a/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/util/DynamoDBDataParser.java
+++ b/emr-dynamodb-hive/src/main/java/org/apache/hadoop/hive/dynamodb/util/DynamoDBDataParser.java
@@ -13,7 +13,6 @@
 
 package org.apache.hadoop.hive.dynamodb.util;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -36,6 +35,7 @@ import org.apache.hadoop.hive.serde2.objectinspector.primitive.DoubleObjectInspe
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.LongObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.StringObjectInspector;
 import org.apache.hadoop.io.BytesWritable;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 public class DynamoDBDataParser {
   private static final Log log = LogFactory.getLog(DynamoDBDataParser.class);

--- a/emr-dynamodb-hive/src/test/java/org/apache/hadoop/hive/dynamodb/DynamoDBObjectInspectorTest.java
+++ b/emr-dynamodb-hive/src/test/java/org/apache/hadoop/hive/dynamodb/DynamoDBObjectInspectorTest.java
@@ -11,7 +11,6 @@
 
 package org.apache.hadoop.hive.dynamodb;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import org.apache.hadoop.dynamodb.DynamoDBItemWritable;
 import org.apache.hadoop.dynamodb.test.DynamoDBTestUtils;
 import org.apache.hadoop.dynamodb.type.DynamoDBTypeConstants;
@@ -26,6 +25,7 @@ import com.google.common.collect.Maps;
 
 import java.util.List;
 import java.util.Map;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 import static org.junit.Assert.assertEquals;
 
@@ -64,10 +64,10 @@ public class DynamoDBObjectInspectorTest {
     expectedRowData.add(Boolean.valueOf(data.get(3)));
 
     Map<String, AttributeValue> itemMap = Maps.newHashMap();
-    itemMap.put(attributeNames.get(0), new AttributeValue(data.get(0)));
-    itemMap.put(attributeNames.get(1), new AttributeValue().withN(data.get(1)));
-    itemMap.put(attributeNames.get(2), new AttributeValue().withN(data.get(2)));
-    itemMap.put(attributeNames.get(3), new AttributeValue().withBOOL(Boolean.valueOf(data.get(3))));
+    itemMap.put(attributeNames.get(0), AttributeValue.fromS(data.get(0)));
+    itemMap.put(attributeNames.get(1), AttributeValue.fromN(data.get(1)));
+    itemMap.put(attributeNames.get(2), AttributeValue.fromN(data.get(2)));
+    itemMap.put(attributeNames.get(3), AttributeValue.fromBool(Boolean.valueOf(data.get(3))));
     List<Object> actualRowData = getDeserializedRow(attributeNames, colTypeInfos, itemMap);
 
     assertEquals(expectedRowData, actualRowData);
@@ -85,8 +85,8 @@ public class DynamoDBObjectInspectorTest {
     expectedRowData.addAll(data);
 
     Map<String, AttributeValue> itemMap = Maps.newHashMap();
-    itemMap.put(attributeNames.get(0), new AttributeValue(data.get(0)));
-    itemMap.put(attributeNames.get(1), new AttributeValue().withNULL(true));
+    itemMap.put(attributeNames.get(0), AttributeValue.fromS(data.get(0)));
+    itemMap.put(attributeNames.get(1), AttributeValue.fromNul(true));
     List<Object> actualRowData = getDeserializedRow(attributeNames, colTypeInfos, itemMap);
 
     assertEquals(expectedRowData, actualRowData);
@@ -101,13 +101,13 @@ public class DynamoDBObjectInspectorTest {
     List<String> items = Lists.newArrayList("milk", "bread", "eggs", "milk");
     List<AttributeValue> itemsAV = Lists.newArrayList();
     for (String item : items) {
-      itemsAV.add(new AttributeValue(item));
+      itemsAV.add(AttributeValue.fromS(item));
     }
     List<Object> expectedRowData = Lists.newArrayList(list, items);
 
     Map<String, AttributeValue> itemMap = Maps.newHashMap();
-    itemMap.put(attributeNames.get(0), new AttributeValue(list));
-    itemMap.put(attributeNames.get(1), new AttributeValue().withL(itemsAV));
+    itemMap.put(attributeNames.get(0), AttributeValue.fromS(list));
+    itemMap.put(attributeNames.get(1), AttributeValue.fromL(itemsAV));
     List<Object> actualRowData = getDeserializedRow(attributeNames, colTypeInfos, itemMap);
 
     assertEquals(expectedRowData, actualRowData);
@@ -117,7 +117,7 @@ public class DynamoDBObjectInspectorTest {
     typeMapping.put(attributeNames.get(1),
         HiveDynamoDBTypeFactory.getTypeObjectFromDynamoDBType(DynamoDBTypeConstants.STRING_SET));
     items = items.subList(0, 3);
-    itemMap.put(attributeNames.get(1), new AttributeValue().withSS(items));
+    itemMap.put(attributeNames.get(1), AttributeValue.fromSs(items));
     expectedRowData.set(1, items);
     actualRowData = getDeserializedRow(attributeNames, colTypeInfos, typeMapping, itemMap);
 
@@ -140,18 +140,18 @@ public class DynamoDBObjectInspectorTest {
       String person = people.get(i);
       long id = (long) i;
 
-      peopleAV.add(new AttributeValue(person));
+      peopleAV.add(AttributeValue.fromS(person));
       ids.put(person, id);
-      idsAV.put(person, new AttributeValue().withN(Long.toString(id)));
+      idsAV.put(person, AttributeValue.fromN(Long.toString(id)));
       lists.put(person, people.subList(0, i + 1));
-      listsAV.put(person, new AttributeValue().withL(Lists.newArrayList(peopleAV)));
+      listsAV.put(person, AttributeValue.fromL(Lists.newArrayList(peopleAV)));
     }
     List<Object> expectedRowData = Lists.newArrayList(map, ids, lists);
 
     Map<String, AttributeValue> itemMap = Maps.newHashMap();
-    itemMap.put(attributeNames.get(0), new AttributeValue(map));
-    itemMap.put(attributeNames.get(1), new AttributeValue().withM(idsAV));
-    itemMap.put(attributeNames.get(2), new AttributeValue().withM(listsAV));
+    itemMap.put(attributeNames.get(0), AttributeValue.fromS(map));
+    itemMap.put(attributeNames.get(1), AttributeValue.fromM(idsAV));
+    itemMap.put(attributeNames.get(2), AttributeValue.fromM(listsAV));
     List<Object> actualRowData = getDeserializedRow(attributeNames, colTypeInfos, itemMap);
 
     assertEquals(expectedRowData, actualRowData);
@@ -166,9 +166,9 @@ public class DynamoDBObjectInspectorTest {
     Map<String, AttributeValue> namesAV = Maps.newHashMap();
     for (String person : people) {
       names.put(person, person);
-      namesAV.put(person, new AttributeValue(person));
+      namesAV.put(person, AttributeValue.fromS(person));
     }
-    itemMap.put(attributeNames.get(3), new AttributeValue().withM(namesAV));
+    itemMap.put(attributeNames.get(3), AttributeValue.fromM(namesAV));
     expectedRowData.add(names);
     actualRowData = getDeserializedRow(attributeNames, colTypeInfos, altTypeMapping, itemMap);
 
@@ -194,14 +194,14 @@ public class DynamoDBObjectInspectorTest {
     expectedRowData.add(structData);
 
     Map<String, AttributeValue> dataAV = Maps.newHashMap();
-    dataAV.put(PRIMITIVE_FIELDS.get(0), new AttributeValue(data.get(0)));
-    dataAV.put(PRIMITIVE_FIELDS.get(1), new AttributeValue().withN(data.get(1)));
-    dataAV.put(PRIMITIVE_FIELDS.get(2), new AttributeValue().withN(data.get(2)));
-    dataAV.put(PRIMITIVE_FIELDS.get(3), new AttributeValue().withBOOL(Boolean.valueOf(data.get(3))));
+    dataAV.put(PRIMITIVE_FIELDS.get(0), AttributeValue.fromS(data.get(0)));
+    dataAV.put(PRIMITIVE_FIELDS.get(1), AttributeValue.fromN(data.get(1)));
+    dataAV.put(PRIMITIVE_FIELDS.get(2), AttributeValue.fromN(data.get(2)));
+    dataAV.put(PRIMITIVE_FIELDS.get(3), AttributeValue.fromBool(Boolean.valueOf(data.get(3))));
 
     Map<String, AttributeValue> itemMap = Maps.newHashMap();
-    itemMap.put(attributeNames.get(0), new AttributeValue(struct));
-    itemMap.put(attributeNames.get(1), new AttributeValue().withM(dataAV));
+    itemMap.put(attributeNames.get(0), AttributeValue.fromS(struct));
+    itemMap.put(attributeNames.get(1), AttributeValue.fromM(dataAV));
 
     List<Object> actualRowData = getDeserializedRow(attributeNames, colTypeInfos, itemMap);
 
@@ -234,10 +234,10 @@ public class DynamoDBObjectInspectorTest {
     expectedRowData.add(colItemMap);
 
     Map<String, AttributeValue> itemMap = Maps.newHashMap();
-    itemMap.put(attributeNames.get(0), new AttributeValue(data.get(0)));
-    itemMap.put(attributeNames.get(1), new AttributeValue().withN(data.get(1)));
-    itemMap.put(attributeNames.get(2), new AttributeValue().withN(data.get(2)));
-    itemMap.put(attributeNames.get(3), new AttributeValue().withBOOL(Boolean.valueOf(data.get(3))));
+    itemMap.put(attributeNames.get(0), AttributeValue.fromS(data.get(0)));
+    itemMap.put(attributeNames.get(1), AttributeValue.fromN(data.get(1)));
+    itemMap.put(attributeNames.get(2), AttributeValue.fromN(data.get(2)));
+    itemMap.put(attributeNames.get(3), AttributeValue.fromBool(Boolean.valueOf(data.get(3))));
 
     List<Object> actualRowData = getDeserializedRow(colNames, colTypeInfos, itemMap);
 

--- a/emr-dynamodb-hive/src/test/java/org/apache/hadoop/hive/dynamodb/DynamoDBSerDeTest.java
+++ b/emr-dynamodb-hive/src/test/java/org/apache/hadoop/hive/dynamodb/DynamoDBSerDeTest.java
@@ -11,7 +11,6 @@
 
 package org.apache.hadoop.hive.dynamodb;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.dynamodb.DynamoDBConstants;
 import org.apache.hadoop.dynamodb.DynamoDBItemWritable;
@@ -33,6 +32,7 @@ import com.google.common.collect.Maps;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 import static org.junit.Assert.assertEquals;
 
@@ -70,10 +70,10 @@ public class DynamoDBSerDeTest {
     List<String> data = PRIMITIVE_STRING_DATA;
 
     Map<String, AttributeValue> expectedItemMap = Maps.newHashMap();
-    expectedItemMap.put(attributeNames.get(0), new AttributeValue(data.get(0)));
-    expectedItemMap.put(attributeNames.get(1), new AttributeValue().withN(data.get(1)));
-    expectedItemMap.put(attributeNames.get(2), new AttributeValue().withN(data.get(2)));
-    expectedItemMap.put(attributeNames.get(3), new AttributeValue().withBOOL(Boolean.valueOf(data.get(3))));
+    expectedItemMap.put(attributeNames.get(0), AttributeValue.fromS(data.get(0)));
+    expectedItemMap.put(attributeNames.get(1), AttributeValue.fromN(data.get(1)));
+    expectedItemMap.put(attributeNames.get(2), AttributeValue.fromN(data.get(2)));
+    expectedItemMap.put(attributeNames.get(3), AttributeValue.fromBool(Boolean.valueOf(data.get(3))));
 
     List<Object> rowData = Lists.newArrayList();
     rowData.add(data.get(0));
@@ -94,7 +94,7 @@ public class DynamoDBSerDeTest {
     data.set(1, null);
 
     Map<String, AttributeValue> expectedItemMap = Maps.newHashMap();
-    expectedItemMap.put(attributeNames.get(0), new AttributeValue(data.get(0)));
+    expectedItemMap.put(attributeNames.get(0), AttributeValue.fromS(data.get(0)));
 
     List<Object> rowData = Lists.newArrayList();
     rowData.addAll(data);
@@ -104,7 +104,7 @@ public class DynamoDBSerDeTest {
     assertEquals(expectedItemMap, actualItemMap);
 
     // with null serialization
-    expectedItemMap.put(attributeNames.get(1), new AttributeValue().withNULL(true));
+    expectedItemMap.put(attributeNames.get(1), AttributeValue.fromNul(true));
     actualItemMap = getSerializedItem(attributeNames, colOIs, rowData, true);
     assertEquals(expectedItemMap, actualItemMap);
   }
@@ -118,12 +118,12 @@ public class DynamoDBSerDeTest {
     List<String> items = Lists.newArrayList("milk", "bread", "eggs", "milk");
     List<AttributeValue> itemsAV = Lists.newArrayList();
     for (String item : items) {
-      itemsAV.add(new AttributeValue(item));
+      itemsAV.add(AttributeValue.fromS(item));
     }
 
     Map<String, AttributeValue> expectedItemMap = Maps.newHashMap();
-    expectedItemMap.put(attributeNames.get(0), new AttributeValue(list));
-    expectedItemMap.put(attributeNames.get(1), new AttributeValue().withL(itemsAV));
+    expectedItemMap.put(attributeNames.get(0), AttributeValue.fromS(list));
+    expectedItemMap.put(attributeNames.get(1), AttributeValue.fromL(itemsAV));
 
     List<Object> rowData = Lists.newArrayList();
     rowData.add(list);
@@ -137,7 +137,7 @@ public class DynamoDBSerDeTest {
     typeMapping.put(attributeNames.get(1), DynamoDBTypeConstants.STRING_SET);
     items = items.subList(0, 3);
     rowData.set(1, items);
-    expectedItemMap.put(attributeNames.get(1), new AttributeValue().withSS(items));
+    expectedItemMap.put(attributeNames.get(1), AttributeValue.fromSs(items));
     actualItemMap = getSerializedItem(attributeNames, colOIs, typeMapping, rowData);
 
     assertEquals(expectedItemMap, actualItemMap);
@@ -160,17 +160,17 @@ public class DynamoDBSerDeTest {
       String person = people.get(i);
       long id = (long) i;
 
-      peopleAV.add(new AttributeValue(person));
+      peopleAV.add(AttributeValue.fromS(person));
       ids.put(person, id);
-      idsAV.put(person, new AttributeValue().withN(Long.toString(id)));
+      idsAV.put(person, AttributeValue.fromN(Long.toString(id)));
       lists.put(person, people.subList(0, i + 1));
-      listsAV.put(person, new AttributeValue().withL(Lists.newArrayList(peopleAV)));
+      listsAV.put(person, AttributeValue.fromL(Lists.newArrayList(peopleAV)));
     }
 
     Map<String, AttributeValue> expectedItemMap = Maps.newHashMap();
-    expectedItemMap.put(attributeNames.get(0), new AttributeValue(map));
-    expectedItemMap.put(attributeNames.get(1), new AttributeValue().withM(idsAV));
-    expectedItemMap.put(attributeNames.get(2), new AttributeValue().withM(listsAV));
+    expectedItemMap.put(attributeNames.get(0), AttributeValue.fromS(map));
+    expectedItemMap.put(attributeNames.get(1), AttributeValue.fromM(idsAV));
+    expectedItemMap.put(attributeNames.get(2), AttributeValue.fromM(listsAV));
 
     List<Object> rowData = Lists.newArrayList();
     rowData.add(map);
@@ -190,10 +190,10 @@ public class DynamoDBSerDeTest {
     Map<String, AttributeValue> namesAV = Maps.newHashMap();
     for (String person : people) {
       names.put(person, person);
-      namesAV.put(person, new AttributeValue(person));
+      namesAV.put(person, AttributeValue.fromS(person));
     }
     rowData.add(names);
-    expectedItemMap.put(attributeNames.get(3), new AttributeValue().withM(namesAV));
+    expectedItemMap.put(attributeNames.get(3), AttributeValue.fromM(namesAV));
     actualItemMap = getSerializedItem(attributeNames, colOIs, typeMapping, rowData);
 
     assertEquals(expectedItemMap, actualItemMap);
@@ -207,14 +207,14 @@ public class DynamoDBSerDeTest {
     String struct = "animal";
     List<String> data = PRIMITIVE_STRING_DATA;
     Map<String, AttributeValue> dataAV = Maps.newHashMap();
-    dataAV.put(PRIMITIVE_FIELDS.get(0), new AttributeValue(data.get(0)));
-    dataAV.put(PRIMITIVE_FIELDS.get(1), new AttributeValue().withN(data.get(1)));
-    dataAV.put(PRIMITIVE_FIELDS.get(2), new AttributeValue().withN(data.get(2)));
-    dataAV.put(PRIMITIVE_FIELDS.get(3), new AttributeValue().withBOOL(Boolean.valueOf(data.get(3))));
+    dataAV.put(PRIMITIVE_FIELDS.get(0), AttributeValue.fromS(data.get(0)));
+    dataAV.put(PRIMITIVE_FIELDS.get(1), AttributeValue.fromN(data.get(1)));
+    dataAV.put(PRIMITIVE_FIELDS.get(2), AttributeValue.fromN(data.get(2)));
+    dataAV.put(PRIMITIVE_FIELDS.get(3), AttributeValue.fromBool(Boolean.valueOf(data.get(3))));
 
     Map<String, AttributeValue> expectedItemMap = Maps.newHashMap();
-    expectedItemMap.put(attributeNames.get(0), new AttributeValue(struct));
-    expectedItemMap.put(attributeNames.get(1), new AttributeValue().withM(dataAV));
+    expectedItemMap.put(attributeNames.get(0), AttributeValue.fromS(struct));
+    expectedItemMap.put(attributeNames.get(1), AttributeValue.fromM(dataAV));
 
     List<Object> structData = Lists.newArrayList();
     structData.add(data.get(0));
@@ -245,10 +245,10 @@ public class DynamoDBSerDeTest {
     );
     List<String> data = PRIMITIVE_STRING_DATA;
     Map<String, AttributeValue> expectedItemMap = Maps.newHashMap();
-    expectedItemMap.put(attributeNames.get(0), new AttributeValue(data.get(0)));
-    expectedItemMap.put(attributeNames.get(1), new AttributeValue().withN(data.get(1)));
-    expectedItemMap.put(attributeNames.get(2), new AttributeValue().withN(data.get(2)));
-    expectedItemMap.put(attributeNames.get(3), new AttributeValue().withBOOL(Boolean.valueOf(data.get(3))));
+    expectedItemMap.put(attributeNames.get(0), AttributeValue.fromS(data.get(0)));
+    expectedItemMap.put(attributeNames.get(1), AttributeValue.fromN(data.get(1)));
+    expectedItemMap.put(attributeNames.get(2), AttributeValue.fromN(data.get(2)));
+    expectedItemMap.put(attributeNames.get(3), AttributeValue.fromBool(Boolean.valueOf(data.get(3))));
 
     Map<String, String> itemCol = Maps.newHashMap();
     for (int i = 0; i < attributeNames.size(); i++) {
@@ -270,7 +270,7 @@ public class DynamoDBSerDeTest {
     colNames.add(attributeNames.get(0));
     colOIs.add(STRING_OBJECT_INSPECTOR);
     rowData.add(animal);
-    expectedItemMap.put(attributeNames.get(0), new AttributeValue(animal));
+    expectedItemMap.put(attributeNames.get(0), AttributeValue.fromS(animal));
     actualItemMap = getSerializedItem(colNames, colOIs, rowData);
 
     assertEquals(expectedItemMap, actualItemMap);

--- a/emr-dynamodb-hive/src/test/java/org/apache/hadoop/hive/dynamodb/DynamoDBStorageHandlerTest.java
+++ b/emr-dynamodb-hive/src/test/java/org/apache/hadoop/hive/dynamodb/DynamoDBStorageHandlerTest.java
@@ -13,10 +13,6 @@
 
 package org.apache.hadoop.hive.dynamodb;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeDefinition;
-import com.amazonaws.services.dynamodbv2.model.KeySchemaElement;
-import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType;
-import com.amazonaws.services.dynamodbv2.model.TableDescription;
 import org.apache.hadoop.dynamodb.DynamoDBConstants;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.MetaException;
@@ -32,6 +28,10 @@ import com.google.common.collect.Maps;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import software.amazon.awssdk.services.dynamodb.model.AttributeDefinition;
+import software.amazon.awssdk.services.dynamodb.model.KeySchemaElement;
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType;
+import software.amazon.awssdk.services.dynamodb.model.TableDescription;
 
 public class DynamoDBStorageHandlerTest {
 
@@ -310,13 +310,20 @@ public class DynamoDBStorageHandlerTest {
   }
 
   private TableDescription getHashRangeTable() {
-    TableDescription description = new TableDescription().withKeySchema(Arrays.asList(
-            new KeySchemaElement().withAttributeName("hashKey"),
-            new KeySchemaElement().withAttributeName("rangeKey"))
-    ).withAttributeDefinitions(Arrays.asList(
-            new AttributeDefinition("hashKey", ScalarAttributeType.S),
-            new AttributeDefinition("rangeKey", ScalarAttributeType.N))
-    );
+    TableDescription description = TableDescription.builder()
+        .keySchema(Arrays.asList(
+            KeySchemaElement.builder().attributeName("hashKey").build(),
+            KeySchemaElement.builder().attributeName("rangeKey").build()))
+        .attributeDefinitions(Arrays.asList(
+            AttributeDefinition.builder()
+                .attributeName("hashKey")
+                .attributeType(ScalarAttributeType.S)
+                .build(),
+            AttributeDefinition.builder()
+                .attributeName("rangeKey")
+                .attributeType(ScalarAttributeType.N)
+                .build()))
+        .build();
     return description;
   }
 }

--- a/emr-dynamodb-tools/src/main/java/org/apache/hadoop/dynamodb/tools/DynamoDBExport.java
+++ b/emr-dynamodb-tools/src/main/java/org/apache/hadoop/dynamodb/tools/DynamoDBExport.java
@@ -13,7 +13,6 @@
 
 package org.apache.hadoop.dynamodb.tools;
 
-import com.amazonaws.services.dynamodbv2.model.TableDescription;
 import java.util.Date;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -32,6 +31,8 @@ import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.lib.IdentityReducer;
 import org.apache.hadoop.util.Tool;
 import org.apache.hadoop.util.ToolRunner;
+import software.amazon.awssdk.services.dynamodb.model.BillingMode;
+import software.amazon.awssdk.services.dynamodb.model.TableDescription;
 
 public class DynamoDBExport extends Configured implements Tool {
 
@@ -106,16 +107,16 @@ public class DynamoDBExport extends Configured implements Tool {
     DynamoDBClient client = new DynamoDBClient(jobConf);
     TableDescription description = client.describeTable(tableName);
 
-    Long itemCount = description.getItemCount();
-    Long tableSizeBytes = description.getTableSizeBytes();
+    Long itemCount = description.itemCount();
+    Long tableSizeBytes = description.tableSizeBytes();
 
-    if (description.getBillingModeSummary() == null
-            || description.getBillingModeSummary().getBillingMode()
-        .equals(DynamoDBConstants.BILLING_MODE_PROVISIONED)) {
+    if (description.billingModeSummary() == null
+            || description.billingModeSummary().billingMode()
+        .equals(BillingMode.PROVISIONED)) {
       jobConf.set(DynamoDBConstants.READ_THROUGHPUT,
-          description.getProvisionedThroughput().getReadCapacityUnits().toString());
+          description.provisionedThroughput().readCapacityUnits().toString());
       jobConf.set(DynamoDBConstants.WRITE_THROUGHPUT,
-          description.getProvisionedThroughput().getWriteCapacityUnits().toString());
+          description.provisionedThroughput().writeCapacityUnits().toString());
     } else {
       // If not specified at the table level, set a hard coded value of 40,000
       jobConf.set(DynamoDBConstants.READ_THROUGHPUT,

--- a/emr-dynamodb-tools/src/main/java/org/apache/hadoop/dynamodb/tools/DynamoDBImport.java
+++ b/emr-dynamodb-tools/src/main/java/org/apache/hadoop/dynamodb/tools/DynamoDBImport.java
@@ -13,7 +13,6 @@
 
 package org.apache.hadoop.dynamodb.tools;
 
-import com.amazonaws.services.dynamodbv2.model.TableDescription;
 import java.util.Date;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -32,6 +31,8 @@ import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.lib.IdentityReducer;
 import org.apache.hadoop.util.Tool;
 import org.apache.hadoop.util.ToolRunner;
+import software.amazon.awssdk.services.dynamodb.model.BillingMode;
+import software.amazon.awssdk.services.dynamodb.model.TableDescription;
 
 public class DynamoDBImport extends Configured implements Tool {
 
@@ -93,13 +94,12 @@ public class DynamoDBImport extends Configured implements Tool {
     DynamoDBClient client = new DynamoDBClient(jobConf);
     TableDescription description = client.describeTable(tableName);
 
-    if (description.getBillingModeSummary() == null
-        || description.getBillingModeSummary().getBillingMode()
-        .equals(DynamoDBConstants.BILLING_MODE_PROVISIONED)) {
+    if (description.billingModeSummary() == null
+        || description.billingModeSummary().billingMode() == BillingMode.PROVISIONED) {
       jobConf.set(DynamoDBConstants.READ_THROUGHPUT,
-          description.getProvisionedThroughput().getReadCapacityUnits().toString());
+          description.provisionedThroughput().readCapacityUnits().toString());
       jobConf.set(DynamoDBConstants.WRITE_THROUGHPUT,
-          description.getProvisionedThroughput().getWriteCapacityUnits().toString());
+          description.provisionedThroughput().writeCapacityUnits().toString());
     } else {
       jobConf.set(DynamoDBConstants.READ_THROUGHPUT,
           DynamoDBConstants.DEFAULT_CAPACITY_FOR_ON_DEMAND.toString());

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     </licenses>
     <properties>
         <java.version>1.8</java.version>
-        <aws-java-sdk.version>1.11.475</aws-java-sdk.version>
+        <aws-java-sdk.version>2.18.40</aws-java-sdk.version>
         <commons-lang3.version>3.7</commons-lang3.version>
         <hadoop.version>3.3.3</hadoop.version>
         <hive1.version>1.0.0</hive1.version>
@@ -68,9 +68,11 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>com.amazonaws</groupId>
-                <artifactId>aws-java-sdk-dynamodb</artifactId>
+                <groupId>software.amazon.awssdk</groupId>
+                <artifactId>bom</artifactId>
                 <version>${aws-java-sdk.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>com.google.guava</groupId>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

> **NOTE** This PR should be merged after #171 .

AWS SDK Java 1.x will enter maintenance mode soon. Upgrade to AWS SDK Java 2.x as recommended by AWS SDK team.

All unit test passed after this change. Test results are pasted as below.

```
-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Running org.apache.hadoop.dynamodb.write.WriteIopsCalculatorTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.586 sec
Running org.apache.hadoop.dynamodb.split.DynamoDBSplitGeneratorTest
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.115 sec
Running org.apache.hadoop.dynamodb.DynamoDBUtilTest
Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.69 sec
Running org.apache.hadoop.dynamodb.test.GsonTest
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.95 sec
Running org.apache.hadoop.dynamodb.DynamoDBFibonacciRetryerTest
Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 40.429 sec
Running org.apache.hadoop.dynamodb.util.ClusterTopologyNodeCapacityProviderTest
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.169 sec
Running org.apache.hadoop.dynamodb.util.RoundRobinYarnContainerAllocatorTest
Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 sec
Running org.apache.hadoop.dynamodb.util.TaskCalculatorTest
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.045 sec
Running org.apache.hadoop.dynamodb.DynamoDBClientTest
Tests run: 18, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 124.523 sec
Running org.apache.hadoop.dynamodb.read.DynamoDBRecordReaderTest
Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.123 sec
Running org.apache.hadoop.dynamodb.read.ReadIopsCalculatorTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.024 sec
Running org.apache.hadoop.dynamodb.read.PageResultMultiplexerTest
Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.742 sec
Running org.apache.hadoop.dynamodb.preader.RateControllerTest
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 19.262 sec
Running org.apache.hadoop.dynamodb.preader.TokenBucketTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.009 sec
Running org.apache.hadoop.dynamodb.preader.ReadManagerTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 6.625 sec
Running org.apache.hadoop.dynamodb.preader.ScanRecordReadRequestTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.058 sec
Running org.apache.hadoop.dynamodb.DynamoDBItemWritableTest
Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.177 sec

Results :

Tests run: 81, Failures: 0, Errors: 0, Skipped: 0

-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Running org.apache.hadoop.hive.dynamodb.util.HiveDynamoDBUtilTest
Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.016 sec
Running org.apache.hadoop.hive.dynamodb.type.HiveDynamoDBTypeTest
Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.214 sec
Running org.apache.hadoop.hive.dynamodb.DynamoDBObjectInspectorTest
Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 sec
Running org.apache.hadoop.hive.dynamodb.DynamoDBStorageHandlerTest
Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.103 sec
Running org.apache.hadoop.hive.dynamodb.filter.DynamoDBFilterPushdownTest
Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.518 sec
Running org.apache.hadoop.hive.dynamodb.DynamoDBSerDeTest
Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.031 sec

Results :

Tests run: 57, Failures: 0, Errors: 0, Skipped: 0

-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Running org.apache.hadoop.dynamodb.exportformat.ExportOutputFormatTest
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.036 sec
Running org.apache.hadoop.dynamodb.exportformat.ExportManifestEntryTest
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.04 sec
Running org.apache.hadoop.dynamodb.exportformat.ExportFileFlusherTest
Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.354 sec

Results :

Tests run: 11, Failures: 0, Errors: 0, Skipped: 0
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
