### PR TITLE
Set RCU/WCU for PROVISIONED tables while maintaining support for autoscaling

### DIFF
--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBConstants.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBConstants.java
@@ -60,11 +60,14 @@ public interface DynamoDBConstants {
   String THROUGHPUT_READ_PERCENT = "dynamodb.throughput.read.percent";
   String READ_THROUGHPUT = "dynamodb.throughput.read";
   String WRITE_THROUGHPUT = "dynamodb.throughput.write";
+  String READ_THROUGHPUT_AUTOSCALING = "dynamodb.throughput.read.autoscaling";
+  String WRITE_THROUGHPUT_AUTOSCALING = "dynamodb.throughput.write.autoscaling";
   String AVG_ITEM_SIZE = "dynamodb.item.average.size";
   String ITEM_COUNT = "dynamodb.item.count";
   String TABLE_SIZE_BYTES = "dynamodb.table.size-bytes";
   String MAX_MAP_TASKS = "dynamodb.max.map.tasks";
   String DEFAULT_THROUGHPUT_PERCENTAGE = "0.5";
+  String DEFAULT_THROUGHPUT_AUTOSCALING = "true";
   String BILLING_MODE_PROVISIONED = BillingMode.PROVISIONED.toString();
 
   String DYNAMODB_MAX_ITEM_SIZE = "dynamodb.max.item.size";

--- a/emr-dynamodb-hadoop/src/test/java/org/apache/hadoop/dynamodb/read/ReadIopsCalculatorTest.java
+++ b/emr-dynamodb-hadoop/src/test/java/org/apache/hadoop/dynamodb/read/ReadIopsCalculatorTest.java
@@ -14,16 +14,20 @@
 package org.apache.hadoop.dynamodb.read;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import org.apache.hadoop.dynamodb.DynamoDBClient;
 import org.apache.hadoop.dynamodb.DynamoDBConstants;
 import org.apache.hadoop.mapred.JobClient;
 import org.apache.hadoop.mapred.JobConf;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
+import software.amazon.awssdk.services.dynamodb.model.BillingMode;
 import software.amazon.awssdk.services.dynamodb.model.BillingModeSummary;
 import software.amazon.awssdk.services.dynamodb.model.ProvisionedThroughputDescription;
 import software.amazon.awssdk.services.dynamodb.model.TableDescription;
@@ -43,31 +47,55 @@ public class ReadIopsCalculatorTest {
 
   private ReadIopsCalculator readIopsCalculator;
 
-  @Before
-  public void setup() {
-    when(dynamoDBClient.describeTable(TABLE_NAME)).thenReturn(TableDescription.builder()
-        .billingModeSummary(BillingModeSummary.builder()
-            .billingMode(DynamoDBConstants.BILLING_MODE_PROVISIONED)
-            .build())
-        .provisionedThroughput(ProvisionedThroughputDescription.builder()
-            .readCapacityUnits(READ_CAPACITY_UNITS)
-            .build())
-        .build());
-
-    JobConf jobConf = new JobConf();
-    jobConf.set(DynamoDBConstants.THROUGHPUT_READ_PERCENT, String.valueOf(THROUGHPUT_READ_PERCENT));
-    when(jobClient.getConf()).thenReturn(jobConf);
-
-    readIopsCalculator = new ReadIopsCalculator(jobClient, dynamoDBClient, TABLE_NAME,
-        TOTAL_SEGMETNS, LOCAL_SEGMENTS);
-  }
-
   @Test
   public void testCalculateTargetIops() {
+    JobConf jobConf = new JobConf();
+    readIopsCalculator = getReadIopsCalculator(jobConf);
+
     long readIops = readIopsCalculator.calculateTargetIops();
     long expectedReadIops = (long) (READ_CAPACITY_UNITS * THROUGHPUT_READ_PERCENT *
         LOCAL_SEGMENTS / TOTAL_SEGMETNS);
     assertEquals(expectedReadIops, readIops);
   }
 
+  @Test
+  public void testCalculateIopsAutoscalingEnabled() {
+    JobConf jobConf = new JobConf();
+    jobConf.set(DynamoDBConstants.READ_THROUGHPUT, "500");
+    readIopsCalculator = getReadIopsCalculator(jobConf);
+
+    ReadIopsCalculator spyIopsCalculator = Mockito.spy(readIopsCalculator);
+    doReturn((double) 1000).when(spyIopsCalculator).getThroughput();
+    long readIops = spyIopsCalculator.calculateTargetIops();
+    long expectedReadIops = (long) (500 * THROUGHPUT_READ_PERCENT *
+        LOCAL_SEGMENTS / TOTAL_SEGMETNS);
+    assertEquals(expectedReadIops, readIops);
+    // Autoscaling not enabled, throughput shouldn't be fetched when user specified
+    verify(spyIopsCalculator, times(0)).getThroughput();
+
+    jobConf.set(DynamoDBConstants.READ_THROUGHPUT_AUTOSCALING, "true");
+    long readIops2 = spyIopsCalculator.calculateTargetIops();
+    long expectedReadIops2 = (long) (1000 * THROUGHPUT_READ_PERCENT *
+        LOCAL_SEGMENTS / TOTAL_SEGMETNS);
+    assertEquals(expectedReadIops2, readIops2);
+    // Autoscaling enabled, throughput should be fetched regardless of if user specified
+    verify(spyIopsCalculator, times(1)).getThroughput();
+  }
+
+  private ReadIopsCalculator getReadIopsCalculator(JobConf jobConf) {
+    when(dynamoDBClient.describeTable(TABLE_NAME)).thenReturn(TableDescription.builder()
+        .billingModeSummary(BillingModeSummary.builder()
+            .billingMode(BillingMode.PROVISIONED)
+            .build())
+        .provisionedThroughput(ProvisionedThroughputDescription.builder()
+            .readCapacityUnits(READ_CAPACITY_UNITS)
+            .build())
+        .build());
+
+    jobConf.set(DynamoDBConstants.THROUGHPUT_READ_PERCENT, String.valueOf(THROUGHPUT_READ_PERCENT));
+    doReturn(jobConf).when(jobClient).getConf();
+
+    return new ReadIopsCalculator(jobClient, dynamoDBClient, TABLE_NAME,
+        TOTAL_SEGMETNS, LOCAL_SEGMENTS);
+  }
 }

--- a/emr-dynamodb-hive/pom.xml
+++ b/emr-dynamodb-hive/pom.xml
@@ -112,6 +112,12 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/emr-dynamodb-tools/src/main/java/org/apache/hadoop/dynamodb/tools/DynamoDBExport.java
+++ b/emr-dynamodb-tools/src/main/java/org/apache/hadoop/dynamodb/tools/DynamoDBExport.java
@@ -117,6 +117,11 @@ public class DynamoDBExport extends Configured implements Tool {
           description.provisionedThroughput().readCapacityUnits().toString());
       jobConf.set(DynamoDBConstants.WRITE_THROUGHPUT,
           description.provisionedThroughput().writeCapacityUnits().toString());
+      // Assume auto-scaling enabled for PROVISIONED tables
+      jobConf.set(DynamoDBConstants.READ_THROUGHPUT_AUTOSCALING,
+          DynamoDBConstants.DEFAULT_THROUGHPUT_AUTOSCALING);
+      jobConf.set(DynamoDBConstants.WRITE_THROUGHPUT_AUTOSCALING,
+          DynamoDBConstants.DEFAULT_THROUGHPUT_AUTOSCALING);
     } else {
       // If not specified at the table level, set a hard coded value of 40,000
       jobConf.set(DynamoDBConstants.READ_THROUGHPUT,

--- a/emr-dynamodb-tools/src/main/java/org/apache/hadoop/dynamodb/tools/DynamoDBImport.java
+++ b/emr-dynamodb-tools/src/main/java/org/apache/hadoop/dynamodb/tools/DynamoDBImport.java
@@ -100,6 +100,11 @@ public class DynamoDBImport extends Configured implements Tool {
           description.provisionedThroughput().readCapacityUnits().toString());
       jobConf.set(DynamoDBConstants.WRITE_THROUGHPUT,
           description.provisionedThroughput().writeCapacityUnits().toString());
+      // Assume auto-scaling enabled for PROVISIONED tables
+      jobConf.set(DynamoDBConstants.READ_THROUGHPUT_AUTOSCALING,
+          DynamoDBConstants.DEFAULT_THROUGHPUT_AUTOSCALING);
+      jobConf.set(DynamoDBConstants.WRITE_THROUGHPUT_AUTOSCALING,
+          DynamoDBConstants.DEFAULT_THROUGHPUT_AUTOSCALING);
     } else {
       jobConf.set(DynamoDBConstants.READ_THROUGHPUT,
           DynamoDBConstants.DEFAULT_CAPACITY_FOR_ON_DEMAND.toString());


### PR DESCRIPTION

*Issue #, if available:*

#158 

*Description of changes:*

Currently we do not configure DynamoDBConstants.READ_THROUGHPUT and DynamoDBConstants.WRITE_THROUGHPUT for PROVISIONED tables in our DynamoDB InputFormat. The reason for this is because PROVISIONED tables can potentially have auto-scaling enabled on Read and Write capacity and every time a new task starts we want to fetch from DDB the current capacity to make sure we are fully utilizing it. However we also use read and write throughput variables to calculate number of mappers so not setting this property initially will cause only one map task to be launched

These changes make it so that even for provisioned tables we initially set the read throughput and write throughput so that we can still estimate number of mappers that will be needed. However instead we pass a new configuration for PROVISIONED tables that indicated that throughput should be fetched every time a new task starts to account for auto-scaling.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
