### PR TITLE
Remove Hive 1.x support

### DIFF
--- a/shims/loader/pom.xml
+++ b/shims/loader/pom.xml
@@ -24,27 +24,12 @@
         </dependency>
         <dependency>
             <groupId>com.amazon.emr</groupId>
-            <artifactId>hive1-shims</artifactId>
-            <version>${project.parent.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.amazon.emr</groupId>
             <artifactId>hive2-shims</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
         <dependency>
             <groupId>com.amazon.emr</groupId>
             <artifactId>shims-common</artifactId>
-            <version>${project.parent.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.amazon.emr</groupId>
-            <artifactId>hive1-shims</artifactId>
-            <version>${project.parent.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.amazon.emr</groupId>
-            <artifactId>hive1.2-shims</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
         <dependency>

--- a/shims/loader/src/main/java/org/apache/hadoop/hive/dynamodb/shims/ShimsLoader.java
+++ b/shims/loader/src/main/java/org/apache/hadoop/hive/dynamodb/shims/ShimsLoader.java
@@ -35,19 +35,7 @@ public final class ShimsLoader {
    */
   private static DynamoDbHiveShims loadHiveShims() {
     String hiveVersion = HiveVersionInfo.getShortVersion();
-    if (DynamoDbHive1Shims.supportsVersion(hiveVersion)) {
-      try {
-        return DynamoDbHive1Shims.class.newInstance();
-      } catch (InstantiationException | IllegalAccessException e) {
-        throw new RuntimeException("unable to get instance of Hive 1.x shim class");
-      }
-    } else if (DynamoDbHive1Dot2Shims.supportsVersion(hiveVersion)) {
-      try {
-        return DynamoDbHive1Dot2Shims.class.newInstance();
-      } catch (InstantiationException | IllegalAccessException e) {
-        throw new RuntimeException("unable to get instance of Hive 1.2.x shim class");
-      }
-    } else if (DynamoDbHive2Shims.supportsVersion(hiveVersion)) {
+    if (DynamoDbHive2Shims.supportsVersion(hiveVersion)) {
       try {
         return DynamoDbHive2Shims.class.newInstance();
       } catch (InstantiationException | IllegalAccessException e) {

--- a/shims/loader/test/main/java/org/apache/hadoop/hive/dynamodb/shims/ShimsLoaderTest.java
+++ b/shims/loader/test/main/java/org/apache/hadoop/hive/dynamodb/shims/ShimsLoaderTest.java
@@ -30,10 +30,6 @@ import org.powermock.modules.junit4.PowerMockRunner;
 @RunWith(PowerMockRunner.class)
 public class ShimsLoaderTest {
 
-  private static final String HIVE_1_VERSION = "1.0.0";
-
-  private static final String HIVE_1_2_VERSION = "1.2.0";
-
   private static final String HIVE_2_VERSION = "2.1.0";
 
   @Before
@@ -47,28 +43,8 @@ public class ShimsLoaderTest {
   }
 
   @Test
-  public void hive1Dot2ShimsClassSupportsCorrectVersion() {
-    assertTrue(DynamoDbHive1Dot2Shims.supportsVersion(HIVE_1_2_VERSION));
-  }
-
-  @Test
-  public void hive1ShimsClassSupportsCorrectVersion() {
-    assertTrue(DynamoDbHive1Shims.supportsVersion(HIVE_1_VERSION));
-  }
-
-  @Test
   public void returnsCorrectShimsImplementationForHive2() {
     assertGetsCorrectShimsClassForVersion(DynamoDbHive2Shims.class, HIVE_2_VERSION);
-  }
-
-  @Test
-  public void returnsCorrectShimsImplementationForHive1Dot2() {
-    assertGetsCorrectShimsClassForVersion(DynamoDbHive1Dot2Shims.class, HIVE_1_2_VERSION);
-  }
-
-  @Test
-  public void returnsCorrectShimsImplementationForHive1() {
-    assertGetsCorrectShimsClassForVersion(DynamoDbHive1Shims.class, HIVE_1_VERSION);
   }
 
   @Test(expected = RuntimeException.class)

--- a/shims/pom.xml
+++ b/shims/pom.xml
@@ -17,8 +17,6 @@
 
     <modules>
         <module>common</module>
-        <module>hive1-shims</module>
-        <module>hive1.2-shims</module>
         <module>hive2-shims</module>
         <module>hive3-shims</module>
         <module>loader</module>


### PR DESCRIPTION
This commit targets to remove support for Hive 1.x since EMR doesn't support Hive 1.x anymore.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
