### PR TITLE
Fix v2 credentials issue

### DIFF
--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBClient.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBClient.java
@@ -467,10 +467,6 @@ public class DynamoDBClient {
       } catch (ClassNotFoundException e) {
         throw new RuntimeException("Custom AWSCredentialsProvider not found: " + providerClass, e);
       }
-    } else {
-      providersList.add(
-          (AwsCredentialsProvider) DefaultCredentialsProvider.create()
-      );
     }
 
     // try to fetch credentials from core-site
@@ -496,6 +492,10 @@ public class DynamoDBClient {
       final AwsCredentials credentials = AwsBasicCredentials.create(accessKey, secretKey);
       providersList.add(() -> credentials);
     }
+
+    providersList.add(
+        (AwsCredentialsProvider) DefaultCredentialsProvider.create()
+    );
 
     AwsCredentialsProvider[] providerArray = providersList.toArray(
         new AwsCredentialsProvider[providersList.size()]

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBClient.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBClient.java
@@ -464,11 +464,13 @@ public class DynamoDBClient {
         providersList.add(
             (AwsCredentialsProvider) ReflectionUtils.newInstance(Class.forName(providerClass), conf)
         );
-      } catch (Exception e) {
-        providersList.add(
-            (AwsCredentialsProvider) DefaultCredentialsProvider.create()
-        );
+      } catch (ClassNotFoundException e) {
+        throw new RuntimeException("Custom AWSCredentialsProvider not found: " + providerClass, e);
       }
+    } else {
+      providersList.add(
+          (AwsCredentialsProvider) DefaultCredentialsProvider.create()
+      );
     }
 
     // try to fetch credentials from core-site

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBClient.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBClient.java
@@ -53,6 +53,7 @@ import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProviderChain;
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.InstanceProfileCredentialsProvider;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.core.exception.SdkException;
@@ -463,8 +464,10 @@ public class DynamoDBClient {
         providersList.add(
             (AwsCredentialsProvider) ReflectionUtils.newInstance(Class.forName(providerClass), conf)
         );
-      } catch (ClassNotFoundException e) {
-        throw new RuntimeException("Custom AWSCredentialsProvider not found: " + providerClass, e);
+      } catch (Exception e) {
+        providersList.add(
+            (AwsCredentialsProvider) DefaultCredentialsProvider.create()
+        );
       }
     }
 


### PR DESCRIPTION
*Issue #, if available:*
SDK v2 no longer supports DefaultAWSCredentialsProviderChain if passed in name-value

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
