### PR TITLE
Fix mvn install

### DIFF
--- a/shims/hive2-shims/pom.xml
+++ b/shims/hive2-shims/pom.xml
@@ -20,6 +20,12 @@
             <groupId>org.apache.hive</groupId>
             <artifactId>hive-exec</artifactId>
             <version>${hive2.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.pentaho</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.amazon.emr</groupId>


### PR DESCRIPTION
This closes #184.

`org.pentaho:pentaho-aggdesigner-algorithm:jar:5.1.5-jhyde` is not available in Maven repo and this change excludes the dependency.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
