### PR TITLE
Add support for custom configuration of the underlying DynamoDbClientBuilder

### DIFF
--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBConstants.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBConstants.java
@@ -30,6 +30,7 @@ public interface DynamoDBConstants {
   String DEFAULT_ACCESS_KEY_CONF = "fs.s3.awsAccessKeyId";
   String DEFAULT_SECRET_KEY_CONF = "fs.s3.awsSecretAccessKey";
   String CUSTOM_CREDENTIALS_PROVIDER_CONF = "dynamodb.customAWSCredentialsProvider";
+  String CUSTOM_CLIENT_BUILDER_TRANSFORMER = "dynamodb.customClientBuilderTransformer";
 
   // Table constants
   String DYNAMODB_COLUMN_MAPPING = "dynamodb.column.mapping";

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDbClientBuilderTransformer.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDbClientBuilderTransformer.java
@@ -1,0 +1,17 @@
+package org.apache.hadoop.dynamodb;
+
+import java.util.function.UnaryOperator;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClientBuilder;
+
+/**
+ * Transformer of a DynamoDbClientBuilder. Takes as a parameter the DynamoDbClientBuilder instance
+ * configured by emr-dynamodb-connector.
+ */
+@FunctionalInterface
+public interface DynamoDbClientBuilderTransformer extends UnaryOperator<DynamoDbClientBuilder> {
+
+  static DynamoDbClientBuilderTransformer identity() {
+    return builder -> builder;
+  }
+
+}


### PR DESCRIPTION
Introduced a new configuration key containing the class name of a transformer to apply to the underlying DynamoDbClientBuilder used by our DynamoDBClient class.

*Description of changes:*

Currently, it is possible to customize the underlying `DynamoDbClient` used by the connector by using some settings in the job configuration (e.g. `DynamoDBConstants.ENDPOINT`, or even `DynamoDBConstants.CUSTOM_CREDENTIALS_PROVIDER_CONF`).

However, some customization are still impossible to achieve in the current situation. For instance, it is not possible to set a custom `EndpointProvider`, or to enable endpoint discovery, or to set a custom auth scheme provider…

This PR addresses these limitations by introducing a new hook allowing the users to have full control over the `DynamoDbClientBuilder` before the connector uses it to build the actual `DynamoDbClient`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
