### PR TITLE
Fix reflection logic of aws-java-sdk-v2 credential providers

### DIFF
--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBClient.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBClient.java
@@ -459,13 +459,7 @@ public class DynamoDBClient {
     // initialized
     String providerClass = conf.get(DynamoDBConstants.CUSTOM_CREDENTIALS_PROVIDER_CONF);
     if (!Strings.isNullOrEmpty(providerClass)) {
-      try {
-        providersList.add(
-            (AwsCredentialsProvider) ReflectionUtils.newInstance(Class.forName(providerClass), conf)
-        );
-      } catch (ClassNotFoundException e) {
-        throw new RuntimeException("Custom AWSCredentialsProvider not found: " + providerClass, e);
-      }
+      providersList.add(DynamoDBUtil.loadAwsCredentialsProvider(providerClass, conf));
     }
 
     // try to fetch credentials from core-site

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBUtil.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBUtil.java
@@ -283,19 +283,26 @@ public final class DynamoDBUtil {
 
   /**
    *
+   * Utility method to load an aws credentials provider from config via reflection. There are two
+   * strategies followed:
+   *   1. Load credential provider via its 'create' method.
+   *      This is the intended credential provider construction mechanism with aws-java-sdk-v2
+   *      For more information, visit {@link <a href="https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/migration-client-credentials.html">Credential Provider Changes</a>}.
+   *   2. If 'create' method is not found, fallback to default no-arg constructor.
+   *      This is kept to ensure utility method maintains backwards compatibility with what it
+   *      used to support.
+   *
    * @param providerClass - class name loaded from conf used as custom credential provider
    * @return - credential provider loaded via reflection using class name from conf
    */
   public static AwsCredentialsProvider loadAwsCredentialsProvider(
       String providerClass,
       Configuration conf) {
-    // First try loading class via static create method which is intended aws-java-sdk-v2 behavior
     if (DynamoDBReflectionUtils.hasFactoryMethod(providerClass, "create")) {
       log.debug("Provider: " + providerClass + " contains required method for creation - create()");
       return DynamoDBReflectionUtils.createInstanceFromFactory(providerClass, conf, "create");
     } else {
       log.debug("Falling back to default constructor.");
-      // To ensure backwards compatibility, fall-back to default no-arg constructor reflection logic
       return DynamoDBReflectionUtils.createInstanceOf(providerClass, conf);
     }
   }

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/util/DynamoDBReflectionUtils.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/util/DynamoDBReflectionUtils.java
@@ -1,0 +1,113 @@
+package org.apache.hadoop.dynamodb.util;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Optional;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.util.ReflectionUtils;
+
+/**
+ * Reflected-utility methods for DynamoDB connector pkg
+ */
+public class DynamoDBReflectionUtils {
+
+  private static final Log log = LogFactory.getLog(DynamoDBReflectionUtils.class);
+
+  // Default no-arg constructor reflection logic
+  public static <T> T createInstanceOf(String className, Configuration conf) {
+    return createInstance(className, conf, null, null);
+  }
+
+  // constructor with-args reflection logic
+  public static <T> T createInstanceOfWithParams(
+      String className,
+      Configuration conf,
+      Class<?>[] paramTypes,
+      Object[] params) {
+    return createInstance(className, conf, paramTypes, params);
+  }
+
+  // checks if class has method available in it
+  public static boolean hasFactoryMethod(String className, String methodName) {
+    Class<?> clazz = getClass(className);
+    return Arrays.stream(clazz.getMethods())
+        .anyMatch(method -> method.getName().equals(methodName));
+  }
+
+  // factory-based reflection logic that uses a method for object construction
+  @SuppressWarnings("unchecked")
+  public static <T> T createInstanceFromFactory(
+      String className,
+      Configuration conf,
+      String methodName) {
+    try {
+      Class<?> clazz = getClass(className);
+      Method m = clazz.getDeclaredMethod(methodName);
+      m.setAccessible(true);
+      T instance = (T) m.invoke(null);
+      log.info("Successfully loaded class: " + className);
+      ReflectionUtils.setConf(instance, conf);
+      log.debug("Configured instance to use conf");
+      return instance;
+
+    } catch (NoSuchMethodException e) {
+      log.error("Method not found for object construction: " + methodName);
+      throw new RuntimeException("Unable to find static method to load class: " + className, e);
+    } catch (InvocationTargetException e) {
+      log.error("Exception found when invoking method for object construction: " + methodName);
+      throw new RuntimeException("Unable to load class: " + className, e);
+    } catch (IllegalAccessException e) {
+      throw new RuntimeException("Class being loaded is not accessible: " + className, e);
+    }
+  }
+
+  // checks if class can be loaded
+  private static Class<?> getClass(String className) {
+    try {
+      return Class.forName(className, true, getContextOrDefaultClassLoader());
+    } catch (ClassNotFoundException e) {
+      throw new RuntimeException("Unable to locate class to load via reflection: " + className, e);
+    }
+  }
+
+  // constructor-based reflection logic
+  @SuppressWarnings("unchecked")
+  private static <T> T createInstance(
+      String className,
+      Configuration conf,
+      Class<?>[] paramTypes,
+      Object[] params) {
+    try {
+      Class<?> clazz = getClass(className);
+      Constructor<T> ctor = paramTypes == null
+          ? (Constructor<T>) clazz.getDeclaredConstructor()
+          : (Constructor<T>) clazz.getDeclaredConstructor(paramTypes);
+      ctor.setAccessible(true);
+      T instance = ctor.newInstance(params);
+      log.info("Successfully loaded class: " + className);
+      ReflectionUtils.setConf(instance, conf);
+      log.debug("Configured instance to use conf");
+      return instance;
+
+    } catch (NoSuchMethodException | InvocationTargetException e) {
+      throw new RuntimeException("Unable to find constructor of class: " + className, e);
+    } catch (IllegalAccessException e) {
+      throw new RuntimeException("Class being loaded is not accessible: " + className, e);
+    } catch (InstantiationException e) {
+      throw new RuntimeException("Unable to instantiate class: " + className, e);
+    }
+  }
+
+  private static ClassLoader getContextOrDefaultClassLoader() {
+    return Optional.of(Thread.currentThread().getContextClassLoader())
+        .orElseGet(DynamoDBReflectionUtils::getDefaultClassLoader);
+  }
+
+  private static ClassLoader getDefaultClassLoader() {
+    return DynamoDBReflectionUtils.class.getClassLoader();
+  }
+}


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
DynamoDB connector uses reflection to load custom credential providers. When the package was upgraded to use aws-java-sdk-v2, the package was only updated to fix the differing classpaths. SDK-v2 credential providers no longer use constructors but static create() methods to initialize the instance which was not handled in the previous implementation. This PR accounts for this use case and includes a fallback to the original logic to ensure backwards compatibility.

*Testing done:*
mvn clean install
```
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for EMRDynamoDBConnector 5.5.0-SNAPSHOT:
[INFO]
[INFO] EMRDynamoDBConnector ............................... SUCCESS [  0.258 s]
[INFO] EMRDynamoDBHadoop .................................. SUCCESS [01:01 min]
[INFO] EMRDynamoDBConnectorShims .......................... SUCCESS [  0.003 s]
[INFO] ShimsCommon ........................................ SUCCESS [  0.394 s]
[INFO] Hive2Shims ......................................... SUCCESS [  0.253 s]
[INFO] Hive3Shims ......................................... SUCCESS [  0.137 s]
[INFO] ShimsLoader ........................................ SUCCESS [  0.142 s]
[INFO] EMRDynamoDBHive .................................... SUCCESS [  2.158 s]
[INFO] EMRDynamoDBTools ................................... SUCCESS [  1.086 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:06 min
[INFO] Finished at: 2024-07-25T16:12:29-07:00
[INFO] ------------------------------------------------------------------------
```
manual testing:
old-behavior by setting:
```
  <property>
          <name>dynamodb.customAWSCredentialsProvider</name>
          <value>org.apache.hadoop.emr.ddb.shaded.software.amazon.awssdk.auth.credentials.InstanceProfileCredentialsProvider</value>
  </property>
  ```
running hive query using ddb connector results in:
```
hive> CREATE EXTERNAL TABLE ddb_features
    >     (feature_id   BIGINT,
    >     feature_name  STRING,
    >     feature_class STRING,
    >     state_alpha   STRING,
    >     prim_lat_dec  DOUBLE,
    >     prim_long_dec DOUBLE,
    >     elev_in_ft    BIGINT)
    > STORED BY 'org.apache.hadoop.hive.dynamodb.DynamoDBStorageHandler'
    > TBLPROPERTIES(
    >     "dynamodb.table.name" = "msugath-features",
    >     "dynamodb.column.mapping"="feature_id:Id,feature_name:Name,feature_class:Class,state_alpha:State,prim_lat_dec:Latitude,prim_long_dec:Longitude,elev_in_ft:Elevation"
    > );
FAILED: Execution Error, return code 1 from org.apache.hadoop.hive.ql.exec.DDLTask. java.lang.RuntimeException: java.lang.NoSuchMethodException: org.apache.hadoop.emr.ddb.shaded.software.amazon.awssdk.auth.credentials.InstanceProfileCredentialsProvider.<init>()
```

new behavior:
```
hive> CREATE EXTERNAL TABLE ddb_features
    >     (feature_id   BIGINT,
    >     feature_name  STRING,
    >     feature_class STRING,
    >     state_alpha   STRING,
    >     prim_lat_dec  DOUBLE,
    >     prim_long_dec DOUBLE,
    >     elev_in_ft    BIGINT)
    > STORED BY 'org.apache.hadoop.hive.dynamodb.DynamoDBStorageHandler'
    > TBLPROPERTIES(
    >     "dynamodb.table.name" = "msugath-features",
    >     "dynamodb.column.mapping"="feature_id:Id,feature_name:Name,feature_class:Class,state_alpha:State,prim_lat_dec:Latitude,prim_long_dec:Longitude,elev_in_ft:Elevation"
    > );
WARNING: Configured write throughput of the dynamodb table msugath-features is less than the cluster map capacity. ClusterMapCapacity: 10 WriteThroughput: 1
WARNING: Writes to this table might result in a write outage on the table.
OK
Time taken: 2.039 seconds
hive> SELECT DISTINCT feature_class
    > FROM ddb_features
    > ORDER BY feature_class;
Query ID = hadoop_20240725231537_249cb0f1-a82e-4cc6-961e-3ae5383cc15b
Total jobs = 1
Launching Job 1 out of 1
Status: Running (Executing on YARN cluster with App id application_1721942632345_0002)

----------------------------------------------------------------------------------------------
        VERTICES      MODE        STATUS  TOTAL  COMPLETED  RUNNING  PENDING  FAILED  KILLED
----------------------------------------------------------------------------------------------
Map 1 .......... container     SUCCEEDED      1          1        0        0       0       0
Reducer 2 ...... container     SUCCEEDED      2          2        0        0       0       0
Reducer 3 ...... container     SUCCEEDED      1          1        0        0       0       0
----------------------------------------------------------------------------------------------
VERTICES: 03/03  [==========================>>] 100%  ELAPSED TIME: 8.28 s
----------------------------------------------------------------------------------------------
OK
Arch
Bar
Basin
Bay
Beach
Bend
Cape
Cliff
Crossing
Falls
Flat
Forest
Gap
Glacier
Island
Lake
Lava
Levee
Range
Ridge
Slope
Spring
Stream
Summit
Swamp
Trail
Valley
Time taken: 11.248 seconds, Fetched: 27 row(s)
```

new behavior (fallback logic by setting a credential provider using a default constructor):
```
hive> SELECT DISTINCT feature_class
    > FROM ddb_features
    > ORDER BY feature_class;
WARNING: Configured write throughput of the dynamodb table msugath-features is less than the cluster map capacity. ClusterMapCapacity: 10 WriteThroughput: 1
WARNING: Writes to this table might result in a write outage on the table.
Query ID = hadoop_20240725232003_663627ff-1d03-47c2-9d3e-1ab047672086
Total jobs = 1
Launching Job 1 out of 1
Status: Running (Executing on YARN cluster with App id application_1721942632345_0003)

----------------------------------------------------------------------------------------------
        VERTICES      MODE        STATUS  TOTAL  COMPLETED  RUNNING  PENDING  FAILED  KILLED
----------------------------------------------------------------------------------------------
Map 1 .......... container     SUCCEEDED      1          1        0        0       0       0
Reducer 2 ...... container     SUCCEEDED      2          2        0        0       0       0
Reducer 3 ...... container     SUCCEEDED      1          1        0        0       0       0
----------------------------------------------------------------------------------------------
VERTICES: 03/03  [==========================>>] 100%  ELAPSED TIME: 8.27 s
----------------------------------------------------------------------------------------------
OK
Arch
Bar
Basin
Bay
Beach
Bend
Cape
Cliff
Crossing
Falls
Flat
Forest
Gap
Glacier
Island
Lake
Lava
Levee
Range
Ridge
Slope
Spring
Stream
Summit
Swamp
Trail
Valley
Time taken: 12.618 seconds, Fetched: 27 row(s)
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
