### PR TITLE
Backport DDB connector Credential Provider Fix EMR 6.15.0 & EMR 7.0.0

### DIFF
--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBClient.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBClient.java
@@ -459,13 +459,7 @@ public class DynamoDBClient {
     // initialized
     String providerClass = conf.get(DynamoDBConstants.CUSTOM_CREDENTIALS_PROVIDER_CONF);
     if (!Strings.isNullOrEmpty(providerClass)) {
-      try {
-        providersList.add(
-            (AwsCredentialsProvider) ReflectionUtils.newInstance(Class.forName(providerClass), conf)
-        );
-      } catch (ClassNotFoundException e) {
-        throw new RuntimeException("Custom AWSCredentialsProvider not found: " + providerClass, e);
-      }
+      providersList.add(DynamoDBUtil.loadAwsCredentialsProvider(providerClass, conf));
     }
 
     // try to fetch credentials from core-site

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBClient.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBClient.java
@@ -46,14 +46,13 @@ import org.apache.hadoop.dynamodb.DynamoDBFibonacciRetryer.RetryResult;
 import org.apache.hadoop.dynamodb.filter.DynamoDBIndexInfo;
 import org.apache.hadoop.dynamodb.filter.DynamoDBQueryFilter;
 import org.apache.hadoop.mapred.Reporter;
-import org.apache.hadoop.util.ReflectionUtils;
 import org.joda.time.Duration;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProviderChain;
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
-import software.amazon.awssdk.auth.credentials.InstanceProfileCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.http.apache.ApacheHttpClient;
@@ -476,7 +475,8 @@ public class DynamoDBClient {
     }
 
     if (Strings.isNullOrEmpty(accessKey) || Strings.isNullOrEmpty(secretKey)) {
-      providersList.add(InstanceProfileCredentialsProvider.create());
+      log.debug("Custom credential provider not found, loading default provider from sdk");
+      providersList.add(DefaultCredentialsProvider.create());
     } else if (!Strings.isNullOrEmpty(sessionKey)) {
       final AwsCredentials credentials =
           AwsSessionCredentials.create(accessKey, secretKey, sessionKey);

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBUtil.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBUtil.java
@@ -41,6 +41,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.dynamodb.util.ClusterTopologyNodeCapacityProvider;
+import org.apache.hadoop.dynamodb.util.DynamoDBReflectionUtils;
 import org.apache.hadoop.dynamodb.util.NodeCapacityProvider;
 import org.apache.hadoop.dynamodb.util.RoundRobinYarnContainerAllocator;
 import org.apache.hadoop.dynamodb.util.TaskCalculator;
@@ -49,6 +50,7 @@ import org.apache.hadoop.mapred.JobClient;
 import org.apache.hadoop.mapred.JobConf;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.regions.internal.util.EC2MetadataUtils;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
@@ -277,6 +279,32 @@ public final class DynamoDBUtil {
 
     // Default to us-east-1 region if all previous attempts fail
     return DynamoDBConstants.DEFAULT_AWS_REGION;
+  }
+
+  /**
+   *
+   * Utility method to load an aws credentials provider from config via reflection. There are two
+   * strategies followed:
+   *   1. Load credential provider via its 'create' method.
+   *      This is the intended credential provider construction mechanism with aws-java-sdk-v2
+   *      For more information, visit {@link <a href="https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/migration-client-credentials.html">Credential Provider Changes</a>}.
+   *   2. If 'create' method is not found, fallback to default no-arg constructor.
+   *      This is kept to ensure utility method maintains backwards compatibility with what it
+   *      used to support.
+   *
+   * @param providerClass - class name loaded from conf used as custom credential provider
+   * @return - credential provider loaded via reflection using class name from conf
+   */
+  public static AwsCredentialsProvider loadAwsCredentialsProvider(
+      String providerClass,
+      Configuration conf) {
+    if (DynamoDBReflectionUtils.hasFactoryMethod(providerClass, "create")) {
+      log.debug("Provider: " + providerClass + " contains required method for creation - create()");
+      return DynamoDBReflectionUtils.createInstanceFromFactory(providerClass, conf, "create");
+    } else {
+      log.debug("Falling back to default constructor.");
+      return DynamoDBReflectionUtils.createInstanceOf(providerClass, conf);
+    }
   }
 
   public static JobClient createJobClient(JobConf jobConf) {

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/util/DynamoDBReflectionUtils.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/util/DynamoDBReflectionUtils.java
@@ -1,0 +1,117 @@
+/**
+ * Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+ * except in compliance with the License. A copy of the License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "LICENSE.TXT" file accompanying this file. This file is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under the License.
+ */
+
+package org.apache.hadoop.dynamodb.util;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Optional;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.util.ReflectionUtils;
+
+/**
+ * Reflected-utility methods for DynamoDB connector pkg
+ */
+public class DynamoDBReflectionUtils {
+
+  private static final Log log = LogFactory.getLog(DynamoDBReflectionUtils.class);
+
+  // Default no-arg constructor reflection logic
+  public static <T> T createInstanceOf(String className, Configuration conf) {
+    return createInstanceOfWithParams(className, conf, null, null);
+  }
+
+  // constructor with-args reflection logic
+  @SuppressWarnings("unchecked")
+  public static <T> T createInstanceOfWithParams(
+      String className,
+      Configuration conf,
+      Class<?>[] paramTypes,
+      Object[] params) {
+    try {
+      Class<?> clazz = getClass(className);
+      Constructor<T> ctor = paramTypes == null
+          ? (Constructor<T>) clazz.getDeclaredConstructor()
+          : (Constructor<T>) clazz.getDeclaredConstructor(paramTypes);
+      ctor.setAccessible(true);
+      T instance = ctor.newInstance(params);
+      log.info("Successfully loaded class: " + className);
+      ReflectionUtils.setConf(instance, conf);
+      log.debug("Configured instance to use conf");
+      return instance;
+
+    } catch (NoSuchMethodException | InvocationTargetException e) {
+      throw new RuntimeException("Unable to find constructor of class: " + className, e);
+    } catch (IllegalAccessException e) {
+      throw new RuntimeException("Class being loaded is not accessible: " + className, e);
+    } catch (InstantiationException e) {
+      throw new RuntimeException("Unable to instantiate class: " + className, e);
+    }
+  }
+
+  // checks if class has method available in it
+  public static boolean hasFactoryMethod(String className, String methodName) {
+    Class<?> clazz = getClass(className);
+    return Arrays.stream(clazz.getMethods())
+        .anyMatch(method -> method.getName().equals(methodName));
+  }
+
+  // factory-based reflection logic that uses a method for object construction
+  @SuppressWarnings("unchecked")
+  public static <T> T createInstanceFromFactory(
+      String className,
+      Configuration conf,
+      String methodName) {
+    try {
+      Class<?> clazz = getClass(className);
+      Method m = clazz.getDeclaredMethod(methodName);
+      m.setAccessible(true);
+      T instance = (T) m.invoke(null);
+      log.info("Successfully loaded class: " + className);
+      ReflectionUtils.setConf(instance, conf);
+      log.debug("Configured instance to use conf");
+      return instance;
+
+    } catch (NoSuchMethodException e) {
+      log.error("Method not found for object construction: " + methodName);
+      throw new RuntimeException("Unable to find static method to load class: " + className, e);
+    } catch (InvocationTargetException e) {
+      log.error("Exception found when invoking method for object construction: " + methodName);
+      throw new RuntimeException("Unable to load class: " + className, e);
+    } catch (IllegalAccessException e) {
+      throw new RuntimeException("Class being loaded is not accessible: " + className, e);
+    }
+  }
+
+  // checks if class can be loaded
+  private static Class<?> getClass(String className) {
+    try {
+      return Class.forName(className, true, getContextOrDefaultClassLoader());
+    } catch (ClassNotFoundException e) {
+      throw new RuntimeException("Unable to locate class to load via reflection: " + className, e);
+    }
+  }
+
+  private static ClassLoader getContextOrDefaultClassLoader() {
+    return Optional.of(Thread.currentThread().getContextClassLoader())
+        .orElseGet(DynamoDBReflectionUtils::getDefaultClassLoader);
+  }
+
+  private static ClassLoader getDefaultClassLoader() {
+    return DynamoDBReflectionUtils.class.getClassLoader();
+  }
+}


### PR DESCRIPTION
*Description of changes:*

This is a backport/cherry pick of issues:
https://github.com/awslabs/emr-dynamodb-connector/pull/201
https://github.com/awslabs/emr-dynamodb-connector/pull/203

View above for more information about the change

*Testing*
mvn clean install
```
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for EMRDynamoDBConnector 5.2.0:
[INFO]
[INFO] EMRDynamoDBConnector ............................... SUCCESS [  0.479 s]
[INFO] EMRDynamoDBHadoop .................................. SUCCESS [01:09 min]
[INFO] EMRDynamoDBConnectorShims .......................... SUCCESS [  0.004 s]
[INFO] ShimsCommon ........................................ SUCCESS [  0.596 s]
[INFO] Hive2Shims ......................................... SUCCESS [  0.392 s]
[INFO] Hive3Shims ......................................... SUCCESS [  0.180 s]
[INFO] ShimsLoader ........................................ SUCCESS [  0.215 s]
[INFO] EMRDynamoDBHive .................................... SUCCESS [  5.900 s]
[INFO] EMRDynamoDBTools ................................... SUCCESS [  1.370 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:18 min
[INFO] Finished at: 2024-08-22T11:06:31-07:00
[INFO] ------------------------------------------------------------------------
```
manual testing:
old-behavior by setting:
```
  <property>
          <name>dynamodb.customAWSCredentialsProvider</name>
          <value>org.apache.hadoop.emr.ddb.shaded.software.amazon.awssdk.auth.credentials.InstanceProfileCredentialsProvider</value>
  </property>
```
before change:
```
hive> CREATE EXTERNAL TABLE ddb_features_615
    >     (feature_id   BIGINT,
    >     feature_name  STRING,
    >     feature_class STRING,
    >     state_alpha   STRING,
    >     prim_lat_dec  DOUBLE,
    >     prim_long_dec DOUBLE,
    >     elev_in_ft    BIGINT)
    > STORED BY 'org.apache.hadoop.hive.dynamodb.DynamoDBStorageHandler'
    > TBLPROPERTIES(
    >     "dynamodb.table.name" = "Features",
    >     "dynamodb.column.mapping"="feature_id:Id,feature_name:Name,feature_class:Class,state_alpha:State,prim_lat_dec:Latitude,prim_long_dec:Longitude,elev_in_ft:Elevation"
    > );
FAILED: Execution Error, return code 1 from org.apache.hadoop.hive.ql.exec.DDLTask. java.lang.RuntimeException: java.lang.NoSuchMethodException: org.apache.hadoop.emr.ddb.shaded.software.amazon.awssdk.auth.credentials.InstanceProfileCredentialsProvider.<init>()
```
after change
```
hive> CREATE EXTERNAL TABLE ddb_features_615
    >     (feature_id   BIGINT,
    >     feature_name  STRING,
    >     feature_class STRING,
    >     state_alpha   STRING,
    >     prim_lat_dec  DOUBLE,
    >     prim_long_dec DOUBLE,
    >     elev_in_ft    BIGINT)
    > STORED BY 'org.apache.hadoop.hive.dynamodb.DynamoDBStorageHandler'
    > TBLPROPERTIES(
    >     "dynamodb.table.name" = "Features",
    >     "dynamodb.column.mapping"="feature_id:Id,feature_name:Name,feature_class:Class,state_alpha:State,prim_lat_dec:Latitude,prim_long_dec:Longitude,elev_in_ft:Elevation"
    > );
hive> SELECT DISTINCT feature_class
    > FROM ddb_features_615
    > ORDER BY feature_class;
Query ID = hadoop_20240822190423_c4fd60ad-2203-41a4-9c3d-d1f863999512
Total jobs = 1
Launching Job 1 out of 1
Status: Running (Executing on YARN cluster with App id application_1724350615438_0003)

----------------------------------------------------------------------------------------------
        VERTICES      MODE        STATUS  TOTAL  COMPLETED  RUNNING  PENDING  FAILED  KILLED
----------------------------------------------------------------------------------------------
Map 1 .......... container     SUCCEEDED      1          1        0        0       0       0
Reducer 2 ...... container     SUCCEEDED      2          2        0        0       0       0
Reducer 3 ...... container     SUCCEEDED      1          1        0        0       0       0
----------------------------------------------------------------------------------------------
VERTICES: 03/03  [==========================>>] 100%  ELAPSED TIME: 7.16 s
----------------------------------------------------------------------------------------------
OK
Arch
Bar
Basin
Bay
Beach
Bend
Cape
Cliff
Crossing
Falls
Flat
Forest
Gap
Glacier
Island
Lake
Lava
Levee
Range
Ridge
Slope
Spring
Stream
Summit
Swamp
Trail
Valley
Time taken: 10.271 seconds, Fetched: 27 row(s)
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
