### PR TITLE
Remove relocation for AWS SDKv2 dependencies

### DIFF
--- a/emr-dynamodb-hadoop/pom.xml
+++ b/emr-dynamodb-hadoop/pom.xml
@@ -63,11 +63,13 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>dynamodb</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>apache-client</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/emr-dynamodb-hive/pom.xml
+++ b/emr-dynamodb-hive/pom.xml
@@ -40,6 +40,18 @@
         </dependency>
 
         <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>dynamodb</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>apache-client</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.hive</groupId>
             <artifactId>hive-service</artifactId>
         </dependency>

--- a/emr-dynamodb-tools/pom.xml
+++ b/emr-dynamodb-tools/pom.xml
@@ -41,6 +41,18 @@
         </dependency>
 
         <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>dynamodb</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>apache-client</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -280,12 +280,6 @@
                                 <include>*:*</include>
                             </includes>
                         </artifactSet>
-                        <relocations>
-                            <relocation>
-                                <pattern>software.amazon.awssdk</pattern>
-                                <shadedPattern>org.apache.hadoop.emr.ddb.shaded.software.amazon.awssdk</shadedPattern>
-                            </relocation>
-                        </relocations>
                         <filters>
                             <filter>
                                 <artifact>*:*</artifact>


### PR DESCRIPTION
*Issue #, if available:*

V1551991884

*Description of changes:*

Remove relocation logic and set dependency scope to `provided` for AWS SDK v2 classes.
This allows customers to use public AWS SDKv2 with the connector and provided scope prevents DDB connector jars from causing version conflicts.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
