### PR TITLE
Remove shading and relocation for AWS SDKv2 dependencies

### DIFF
--- a/emr-dynamodb-hadoop/pom.xml
+++ b/emr-dynamodb-hadoop/pom.xml
@@ -63,11 +63,13 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>dynamodb</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>apache-client</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/emr-dynamodb-hive/pom.xml
+++ b/emr-dynamodb-hive/pom.xml
@@ -40,6 +40,18 @@
         </dependency>
 
         <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>dynamodb</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>apache-client</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.hive</groupId>
             <artifactId>hive-service</artifactId>
         </dependency>

--- a/emr-dynamodb-tools/pom.xml
+++ b/emr-dynamodb-tools/pom.xml
@@ -41,6 +41,18 @@
         </dependency>
 
         <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>dynamodb</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>apache-client</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -280,12 +280,6 @@
                                 <include>*:*</include>
                             </includes>
                         </artifactSet>
-                        <relocations>
-                            <relocation>
-                                <pattern>software.amazon.awssdk</pattern>
-                                <shadedPattern>org.apache.hadoop.emr.ddb.shaded.software.amazon.awssdk</shadedPattern>
-                            </relocation>
-                        </relocations>
                         <filters>
                             <filter>
                                 <artifact>*:*</artifact>


### PR DESCRIPTION
*Description of changes:*

Remove relocation logic and set dependency scope to provided for AWS SDK v2 classes.
This allows customers to use public AWS SDKv2 with the connector and provided scope prevents DDB connector jars from causing version conflicts.

Cherry pick of PR - https://github.com/awslabs/emr-dynamodb-connector/pull/212

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

mvn clean install
```
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for EMRDynamoDBConnector 5.5.0:
[INFO] 
[INFO] EMRDynamoDBConnector ............................... SUCCESS [  0.441 s]
[INFO] EMRDynamoDBHadoop .................................. SUCCESS [01:05 min]
[INFO] EMRDynamoDBConnectorShims .......................... SUCCESS [  0.005 s]
[INFO] ShimsCommon ........................................ SUCCESS [  0.525 s]
[INFO] Hive2Shims ......................................... SUCCESS [  0.354 s]
[INFO] Hive3Shims ......................................... SUCCESS [  0.227 s]
[INFO] ShimsLoader ........................................ SUCCESS [  0.245 s]
[INFO] EMRDynamoDBHive .................................... SUCCESS [  3.134 s]
[INFO] EMRDynamoDBTools ................................... SUCCESS [  1.369 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:12 min
[INFO] Finished at: 2024-10-28T12:31:14-07:00
[INFO] ------------------------------------------------------------------------
```

testing

Change was tested on EMR Serverless with a custom image.
script
```
SparkSession spark = SparkSession.builder()
        .appName("ddb-connector-test")
        .getOrCreate();

    JobConf jc = new JobConf(spark.sparkContext().hadoopConfiguration());

    jc.set("dynamodb.region", "us-east-1");
    jc.set("dynamodb.output.tableName", "xxx");
    jc.set("mapred.output.format.class", "org.apache.hadoop.dynamodb.write.DynamoDBOutputFormat");
    jc.set("mapred.input.format.class", "org.apache.hadoop.dynamodb.read.DynamoDBInputFormat");

    List<StructField> schemaFields = new ArrayList<>();
    schemaFields.add(DataTypes.createStructField("messgae_id", DataTypes.StringType, false));
    schemaFields.add(DataTypes.createStructField("account_id", DataTypes.StringType, false));
    StructType schema = DataTypes.createStructType(schemaFields);

    List<Row> rows = new ArrayList<>();
    rows.add(RowFactory.create("12345", "123456789012"));
    rows.add(RowFactory.create("67890", "012345678901"));

    Dataset<Row> ds = spark.createDataset(rows, Encoders.row(schema));

    JavaPairRDD<Text, DynamoDBItemWritable> dynamoRDD = ds.javaRDD().mapToPair(row -> {
      DynamoDBItemWritable item = new DynamoDBItemWritable();
      Map<String, AttributeValue> attributeMap = new HashMap<>();
      attributeMap.put("messgae_id", AttributeValue.builder().s(row.getString(0)).build());
      attributeMap.put("account_id", AttributeValue.builder().s(row.getString(1)).build());
      item.setItem(attributeMap);
      return new Tuple2<>(new Text(""), item);
    });

    dynamoRDD.saveAsHadoopDataset(jc);
```
job
```
{
    "executionRoleArn": "arn:aws:iam::xxx:role/ExecutionRole",
    "jobDriver": {
        "sparkSubmit": {
            "entryPoint": "s3://test-jar.jar",
            "entryPointArguments": [],
            "sparkSubmitParameters": "--class com.x.App --conf spark.jars=/usr/share/aws/emr/ddb/lib/emr-ddb-hadoop.jar --conf spark.executor.cores=4 --conf spark.executor.memory=4g --conf spark.executor.instances=2 --conf spark.driver.cores=4 --conf spark.driver.memory=4g --conf spark.dynamicAllocation.enabled=false"
        }
    },
    "configurationOverrides": {
        "monitoringConfiguration": {
             "s3MonitoringConfiguration": {
                 "logUri": "s3://logs"
             }
        }
    }
}
```
Items were successfully written to ddb table.
```
{
    "Items": [
        {
            "account_id": {
                "S": "123456789012"
            },
            "message_id": {
                "S": "12345"
            }
        },
        {
            "account_id": {
                "S": "012345678901"
            },
            "message_id": {
                "S": "67890"
            }
        }
    ],
    "Count": 2,
    "ScannedCount": 2,
    "ConsumedCapacity": null
}
```